### PR TITLE
Simplified the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,34 @@
-# Documentation
-
-[Documents Website](https://api3dao.github.io/api3-docs/)
-
----
-
 <p align="center">
   <img src="https://github.com/api3dao/api3-docs/raw/master/figures/api3.png" width="400" />
 </p>
 
-*API3 documentation is kept as a regular repository of Markdown files for everyone to be able to easily contribute.
-Feel free to create [issues](https://github.com/api3dao/api3-docs/issues) for discussions, proposed additions and changes.*
+# Documentation
+
+**[API3 Documentation](https://api3dao.github.io/api3-docs/)** is kept as a regular repository of Markdown files making it easy for everyone to contribute. Feel free to create [issues](https://github.com/api3dao/api3-docs/issues) for discussions, proposed additions and changes.
 
 ## What is API3?
 
-[API3](https://api3.org/) is a collaborative project to deliver traditional API services to smart contract platforms in a decentralized and trust-minimized way.
-It is governed by a decentralized autonomous organization (DAO), its code is open source and its operations are transparent.
+[API3](https://api3.org/) is a collaborative project to deliver traditional API services to smart contract platforms in a decentralized and trust-minimized way. It is governed by a decentralized autonomous organization (DAO), its code is open source and its operations are transparent.
 
 ## API3 thesis statement
 
-The vast majority of the external integrations that decentralized applications need are to commercial Web APIs that traditional businesses have built to monetize their data and services.
-Therefore, what is widely known as *the oracle problem* is in practice *the API connectivity problem*.
-Existing oracle solutions fall short because they fail to make this distinction, resulting in inferior solutions that depend on third-party oracles and ecosystems that exclude API providers.
-By refining the definition of the problem, API3 aims to provide a much more optimal solution.
+The vast majority of the external integrations that decentralized applications need are to commercial Web APIs that traditional businesses have built to monetize their data and services. Therefore, what is widely known as *the oracle problem* is in practice *the API connectivity problem*. Existing oracle solutions fall short because they fail to make this distinction, resulting in inferior solutions that depend on third-party oracles and ecosystems that exclude API providers. By refining the definition of the problem, API3 aims to provide a much more optimal solution.
 
 ## Whitepaper
 
-See the [whitepaper](https://raw.githubusercontent.com/api3dao/api3-whitepaper/master/api3-whitepaper.pdf) for a detailed discussion of the project.
-Just as these docs, you can discuss it and propose updates through [issues](https://github.com/api3dao/api3-whitepaper/issues).
+See the [whitepaper](https://raw.githubusercontent.com/api3dao/api3-whitepaper/master/api3-whitepaper.pdf) for a detailed discussion of the project. Just as these docs, you can discuss it and propose updates through [issues](https://github.com/api3dao/api3-whitepaper/issues).
 
 ## Medium posts
 
-See a grouped list of our Medium posts [here](/medium.md).
-
-## Fundamentals
-
-An introduction to the API connectivity problem and API3's solution
-
-- [API](/fundamentals/api.md)
-- [First-party oracles](/fundamentals/first-party-oracles.md)
-- [Decentrally-governed oracle networks](/fundamentals/decentrally-governed-oracle-networks.md)
-- [dAPI](/fundamentals/dapi.md)
-
-*See our article, [API3: The Glue Connecting the Blockchain to the Digital World](https://medium.com/api3/api3-the-glue-connecting-the-blockchain-to-the-digital-world-129e61ec598f) for an overview of the API3 solution.*
-
-## Airnode
-
-The design of Airnode and specification details
-
-- [Design philosophy](/airnode/design-philosophy.md)
-- [Implementation](/airnode/implementation.md)
-- [Ethereum providers](/airnode/ethereum-providers.md)
-- [OIS](/airnode/ois.md)
-- [`config.json`](/airnode/config-json.md)
-- [`security.json`](/airnode/security-json.md)
-- [Airnode ABI specifications](/airnode/airnode-abi-specifications.md)
-- [Reserved parameters](/airnode/reserved-parameters.md)
-
-## Request–response protocol
-
-The description of the components of the request–response protocol and how they interrelate
-
-- [General structure](/request-response-protocol/general-structure.md)
-- [Provider](/request-response-protocol/provider.md)
-- [Endpoint](/request-response-protocol/endpoint.md)
-- [Authorizer](/request-response-protocol/authorizer.md)
-- [Requester](/request-response-protocol/requester.md)
-- [Client](/request-response-protocol/client.md)
-- [Designated wallet](/request-response-protocol/designated-wallet.md)
-- [Endorsement](/request-response-protocol/endorsement.md)
-- [Template](/request-response-protocol/template.md)
-- [Request](/request-response-protocol/request.md)
-
-## Provider guides
-
-- [API integration](/provider-guides/api-integration.md)
-- [Configuring Airnode](/provider-guides/configuring-airnode.md)
-- [Deploying Airnode](/provider-guides/deploying-airnode.md)
-- [Setting authorizers](/provider-guides/setting-authorizers.md)
-
-## Requester guides
-
-- [Creating a requester](/requester-guides/creating-a-requester.md)
-- [Developing a client contract](/requester-guides/developing-a-client-contract.md)
-
-Refer to the [Airnode starter](https://github.com/api3dao/airnode-starter) repo, where these provider and requester guides are reiterated with a real API on a public chain.
-
-## Smart contract platform guides
-
-- [Is my platform compatible?](/smart-contract-platform-guides/is-my-platform-compatible.md)
-- [Self-serve integration](/smart-contract-platform-guides/self-serve%20integration.md)
-
-# Community
+See a grouped list of our Medium posts [here](https://medium.com/api3).
 
 ## Become a part of API3
 
-API3 is formed by people who spontaneously found each other through a common understanding.
-Despite being largely overlooked, the API connectivity problem is the most critical obstacle in front of meaningful decentralized applications being built at scale.
+API3 is formed by people who spontaneously found each other through a common understanding. Despite being largely overlooked, the API connectivity problem is the most critical obstacle in front of meaningful decentralized applications being built at scale.
 
-If existing oracle solutions do not fulfill the needs of the decentralized applications you want to build, give you a fair opportunity to monetize your API business, or feel like they are working against the ethos of decentralization, we invite you to be a part of API3 so that we can solve the API connectivity problem together.
-If you are coming from a technical background, see our [guide](/CONTRIBUTING.md) to get you started on contributing.
+If existing oracle solutions do not fulfill the needs of the decentralized applications you want to build, give you a fair opportunity to monetize your API business, or feel like they are working against the ethos of decentralization, we invite you to be a part of API3 so that we can solve the API connectivity problem together. If you are coming from a technical background, see our [guide](https://docs.api3.org/pre-alpha/introduction/contributing.html) to get you started on contributing.
 
-The API connectivity problem is in essence an ecosystem building problem, more so than a technical one.
-This means that API3 can use the skills of all kinds of experts and the decentralized nature of the project will allow you to shape it in a way that makes the best use of your skills.
+The API connectivity problem is in essence an ecosystem building problem, more so than a technical one. This means that API3 can use the skills of all kinds of experts and the decentralized nature of the project will allow you to shape it in a way that makes the best use of your skills.
 
 ## Communication channels
 
@@ -113,3 +40,4 @@ This means that API3 can use the skills of all kinds of experts and the decentra
 
 **Medium publication of the DAO:** https://medium.com/api3
 
+**[API3 Documentation](https://api3dao.github.io/api3-docs/)**


### PR DESCRIPTION
Removed links to old docs. Going forward repo root README files will have minimal info and point to the api3-docs repo Docs at https://docs.api3.org