### PR TITLE
Issue #71 - fixedOperationParameters not really optional

### DIFF
--- a/docs/next/technology/specifications/ois.md
+++ b/docs/next/technology/specifications/ois.md
@@ -269,8 +269,7 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 
 ### 5.3. `fixedOperationParameters`
 
-(Optional) A list of objects specifying fixed operation parameters.
-Each object has the following elements:
+(Required) A list of objects specifying fixed operation parameters. While required, the fixedOperationParameters array can be left empty. Each object has the following elements:
 
 - [`operationParameter`](#531-operationParameter)
 - [`value`](#532-value)

--- a/docs/pre-alpha/airnode/specifications/ois.md
+++ b/docs/pre-alpha/airnode/specifications/ois.md
@@ -269,8 +269,7 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 
 ### 5.3. `fixedOperationParameters`
 
-(Optional) A list of objects specifying fixed operation parameters.
-Each object has the following elements:
+(Required) A list of objects specifying fixed operation parameters. While required, the fixedOperationParameters array can be left empty. Each object has the following elements:
 
 - [`operationParameter`](#531-operationParameter)
 - [`value`](#532-value)


### PR DESCRIPTION
The intended behavior is for fixedOperationParameters to be required even if it's empty. Changes made to the OIS specification (_ois.md_) doc for both /pre-alpha and /next. Now reads as follows.

**(Required) A list of objects specifying fixed operation parameters. While required, the fixedOperationParameters array can be left empty. Each object has the following elements:**

This change will appear in tonight's build of the docs.