### PR TITLE
Moved to community TOC Vue component

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,7 +14,6 @@ module.exports = {
   description: 'Technical Documentation for API3 ',
   markdown: {
     lineNumbers: true,
-    toc: { includeLevel: [2, 3] },
   },
   themeConfig: {
     startPath:'/pre-alpha/',

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -9,7 +9,7 @@ title: What is API?
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 **API3** ([https://api3.org](https://api3.org)) is a collaborative project to deliver traditional API services to smart contract platforms in a decentralized and trust-minimized way. It is governed by a _decentralized autonomous organization_ (DAO), namely the **API3 DAO**. Therefore, its code is open source and its operations are transparent.
 

--- a/docs/next/contributing.md
+++ b/docs/next/contributing.md
@@ -4,7 +4,7 @@ title: Contributing
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 (To the API3 DAO as a technical member)
 

--- a/docs/next/fundamentals/apis.md
+++ b/docs/next/fundamentals/apis.md
@@ -5,7 +5,7 @@ title: API (Application programming interface)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [APIs: The Digital Glue](https://medium.com/api3/apis-the-digital-glue-7ac87566e773) for a more complete background on APIs.*
 

--- a/docs/next/fundamentals/dapis.md
+++ b/docs/next/fundamentals/dapis.md
@@ -4,7 +4,7 @@ title: dAPI (Decentralized API)
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Consider the following:
 

--- a/docs/next/fundamentals/decentrally-governed-oracle-networks.md
+++ b/docs/next/fundamentals/decentrally-governed-oracle-networks.md
@@ -4,7 +4,7 @@ title: Decentrally-governed oracle networks
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [On DAOs: Decentralized Autonomous Organizations](https://medium.com/api3/on-daos-decentralized-autonomous-organizations-84c00abb89bc) on DAOs and decentralized governance.*
 

--- a/docs/next/fundamentals/first-party-oracles.md
+++ b/docs/next/fundamentals/first-party-oracles.md
@@ -4,7 +4,7 @@ title: First-party oracles
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle is an agent that acts as an intermediary between a smart contract platform and an API.
 In other words, a decentralized application can use an oracle to call an API.

--- a/docs/next/grp-members/README.md
+++ b/docs/next/grp-members/README.md
@@ -5,7 +5,7 @@ title: API3 DAO
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 API3 is governed by a Decentralized Autonomous Organization, DAO. The DAO is a collaborative effort to build, manage and monetize dAPIs at scale. To achieve this in a fully decentralized way, the incentives of the participants are reconciled through the governance, security, and [value capture utilities](dao-pool.md#token-utilities) of the API3 token.
 

--- a/docs/next/grp-members/dao-pool.md
+++ b/docs/next/grp-members/dao-pool.md
@@ -5,7 +5,7 @@ title: The DAO Pool
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 The API3 DAO has a single staking pool called the **DAO pool**. Staking API3 tokens in the pool will grant representation and staking rewards, but at the same time, the staked tokens will be used as collateral to pay out insurance claims as needed. To do this, the pool focuses on three token utilities and implements an insurance service which by design balances rewards and risks through responsible governance.
 

--- a/docs/next/grp-members/dashboard/pool.md
+++ b/docs/next/grp-members/dashboard/pool.md
@@ -5,7 +5,7 @@ title: Monitor the Insurance Pool
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 > Content
 > 

--- a/docs/next/grp-members/dashboard/staking-tokens.md
+++ b/docs/next/grp-members/dashboard/staking-tokens.md
@@ -5,7 +5,7 @@ title: How to Stake
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 > Content
 > 

--- a/docs/next/grp-members/dashboard/vote.md
+++ b/docs/next/grp-members/dashboard/vote.md
@@ -5,4 +5,4 @@ title: Voting
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />

--- a/docs/next/grp-members/tokens.md
+++ b/docs/next/grp-members/tokens.md
@@ -5,7 +5,7 @@ title: Tokens
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 API3 is the native token of the API3 project. The API3 ecosystem is a single token environment. Check out the Medium post [API3 Tokenomics Update](https://medium.com/api3/api3-tokenomics-update-f032d6e49b30) for an in-depth overview on API3 tokenomics.
 

--- a/docs/next/grp-providers/airnode/design-philosophy.md
+++ b/docs/next/grp-providers/airnode/design-philosophy.md
@@ -5,7 +5,7 @@ title: Airnode design philosophy
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Airnode: The API gateway for blockchains](https://medium.com/api3/airnode-the-api-gateway-for-blockchains-8b07ff136840) for a high level overview of Airnode.*
 

--- a/docs/next/grp-providers/airnode/ethereum-providers.md
+++ b/docs/next/grp-providers/airnode/ethereum-providers.md
@@ -4,7 +4,7 @@ title: Ethereum providers
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle node requires access to a blockchain (e.g., Ethereum) node to listen for request events and send transactions to fulfill requests.
 The Airnode model aims to minimize the node operation effort using managed services wherever possible.

--- a/docs/next/grp-providers/airnode/implementation.md
+++ b/docs/next/grp-providers/airnode/implementation.md
@@ -5,7 +5,7 @@ title: Airnode implementation
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Getting to know Airnode](https://medium.com/api3/getting-to-know-airnode-162e50ea243e) for a technical overview of the software.*
 

--- a/docs/next/grp-providers/guides/docker/client-image.md
+++ b/docs/next/grp-providers/guides/docker/client-image.md
@@ -4,7 +4,7 @@ title: Client image instructions
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 1. Build the Docker image (you can skip this step and fetch the pre-built image)
 ```sh

--- a/docs/next/grp-providers/guides/docker/deployer-image.md
+++ b/docs/next/grp-providers/guides/docker/deployer-image.md
@@ -5,7 +5,7 @@ title: Deployer image instructions
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 1. Build the Docker image
 ```sh

--- a/docs/next/grp-providers/guides/provider/api-integration-orig.md
+++ b/docs/next/grp-providers/guides/provider/api-integration-orig.md
@@ -5,7 +5,7 @@ title: API integration (orig)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 To integrate a System X to a System Y, we need to do three things:
 - Specify the interface of System X

--- a/docs/next/grp-providers/guides/provider/api-integration.md
+++ b/docs/next/grp-providers/guides/provider/api-integration.md
@@ -5,7 +5,7 @@ title: API Integration
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A successful integration of an API with an Airnode requires the mapping of each other's interface. This is accomplished using an OIS ([Oracle Integration Specifications](../../../technology/specifications/ois.md)) json object that is designed to follow three basic steps.
 

--- a/docs/next/grp-providers/guides/provider/configuring-airnode-orig.md
+++ b/docs/next/grp-providers/guides/provider/configuring-airnode-orig.md
@@ -5,7 +5,7 @@ title: Configuring Airnode (orig)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Users configure their Airnodes by providing a `config.json` and a `security.json` file during deployment/redeployment.
 `config.json` specifies the API–oracle integration specifications in the form of [OIS](../../../technology/specifications/ois.md)es, but also user-specific configuration details.

--- a/docs/next/grp-providers/guides/provider/configuring-airnode.md
+++ b/docs/next/grp-providers/guides/provider/configuring-airnode.md
@@ -5,7 +5,7 @@ title: Configuring Airnode
 # {{$frontmatter.title}}
 
 <TocHeader />
-<TOC class="table-of-contents" :include-level="[2,4]" />
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An Airnode is deployed or redeployed using configuration values from its `config.json` and `secrets.env` files. The  `config.json` specifies the [OIS](../../../technology/specifications/ois.md) (Oracle Integration Specifications) and other specific configuration details. The `secrets.env` file includes security credentials such as API keys and chain provider URLs.
 

--- a/docs/next/grp-providers/guides/provider/deploying-airnode-orig.md
+++ b/docs/next/grp-providers/guides/provider/deploying-airnode-orig.md
@@ -5,7 +5,7 @@ title: Deploying Airnode (orig)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 After [integrating your API](api-integration.md) and [creating the configuration files](configuring-airnode.md), the next step is to deploy your Airnode.
 Airnode comes with a [deployer](https://github.com/api3dao/airnode/tree/pre-alpha/packages/deployer), which uses [Terraform](https://www.terraform.io/) and [Serverless Framework](https://www.serverless.com/) to automate the entire deployment process.

--- a/docs/next/grp-providers/guides/provider/deploying-airnode.md
+++ b/docs/next/grp-providers/guides/provider/deploying-airnode.md
@@ -5,7 +5,7 @@ title: Deploying Airnode
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 After integrating your API ([API Integration](api-integration.md)) and creating the configuration files ([Configuring Airnode](configuring-airnode.md)), the next step is to deploy your Airnode. Airnode comes with a [deployer](https://github.com/api3dao/airnode/tree/pre-alpha/packages/deployer), which uses [Terraform](https://www.terraform.io/) and [Serverless Framework](https://www.serverless.com/) to automate the entire deployment process. Rather than using the deployer directly it is recommended to use the provided Docker image.
 

--- a/docs/next/grp-providers/guides/provider/setting-authorizers-orig.md
+++ b/docs/next/grp-providers/guides/provider/setting-authorizers-orig.md
@@ -5,7 +5,7 @@ title: Setting authorizers (orig)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 We are assuming that you have [configured your Airnode](configuring-airnode.md) (and set `endpointId`s of your endpoints), and [deployed your Airnode](deploying-airnode.md) and received your `providerId` in your receipt file.
 Requesters who know your `providerId` and `endpointId`s should now be able to make requests to your endpoints.

--- a/docs/next/grp-providers/guides/provider/setting-authorizers.md
+++ b/docs/next/grp-providers/guides/provider/setting-authorizers.md
@@ -5,7 +5,7 @@ title: Setting Authorizers
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Complete the following before settings authorizers.
 

--- a/docs/next/grp-providers/tutorial/airnode-starter.md
+++ b/docs/next/grp-providers/tutorial/airnode-starter.md
@@ -5,7 +5,7 @@ title: Airnode starter
 <!-- markdownlint-disable -->
 # {{$frontmatter.title}}
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 <!-- markdownlint-enable -->
 
 > A starter project for deploying an Airnode and making requests to it

--- a/docs/next/grp-requesters/guides/requester/creating-a-requester.md
+++ b/docs/next/grp-requesters/guides/requester/creating-a-requester.md
@@ -4,7 +4,7 @@ title: Creating a requester
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Each requester needs to create a requester record, and get assigned a requester index.
 This is fairly early, using [@api3/airnode-admin](https://github.com/api3dao/airnode/tree/pre-alpha/packages/admin#create-requester).

--- a/docs/next/grp-requesters/guides/requester/developing-a-client-contract.md
+++ b/docs/next/grp-requesters/guides/requester/developing-a-client-contract.md
@@ -5,7 +5,7 @@ title: Developing a client contract
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A [client](../../../technology/protocols/request-response/client.md) is a contract that makes requests to [providers](../../../technology/protocols/request-response/provider.md) using the [Airnode.sol](../../../technology/protocols/request-response/general-structure.md#airnode-sol) contract that implements the protocol.
 A client is [endorsed](../../../technology/protocols/request-response/endorsement.md) by a [requester](../../../technology/protocols/request-response/requester.md), which means that it can specify its request to be fulfilled by the respective requester's [designated wallet](../../../technology/protocols/request-response/designated-wallet.md).

--- a/docs/next/grp-requesters/guides/smart-contracts-platform/is-my-platform-compatible.md
+++ b/docs/next/grp-requesters/guides/smart-contracts-platform/is-my-platform-compatible.md
@@ -5,7 +5,7 @@ title: Is my platform compatible?
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 We are receiving an overwhelming amount of demand by teams of smart contract platforms and decentralized applications built on these about integrating Airnode to gain access to API data and services.
 These guides are for you to be able to self-serve to assess the feasibility of an integration, and even prototype the integration yourself.

--- a/docs/next/grp-requesters/guides/smart-contracts-platform/self-serve-integration.md
+++ b/docs/next/grp-requesters/guides/smart-contracts-platform/self-serve-integration.md
@@ -5,7 +5,7 @@ title: Self-serve integration
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Assuming you have determined that your platform [is compatible](is-my-platform-compatible.md), you can attempt to do the integration yourself by following the steps below.
 

--- a/docs/next/homeless/hardhat-starter.md
+++ b/docs/next/homeless/hardhat-starter.md
@@ -5,7 +5,7 @@ title: Hardhat Starter
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 :::tip 
 The file is not intended to be part of the docs.

--- a/docs/next/technology/deployment-files/overview.md
+++ b/docs/next/technology/deployment-files/overview.md
@@ -5,7 +5,7 @@ title: Deployment Files Overview
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Airnode is deployed with two files:
 

--- a/docs/next/technology/deployment-files/receipt-json.md
+++ b/docs/next/technology/deployment-files/receipt-json.md
@@ -5,7 +5,7 @@ title: receipt.json
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A `receipt.json` file is outputted after deployment that has (non-sensitive) information about the deployments.
 The main use of a receipt file is to detect deployments that are now obsolete and need to be removed.

--- a/docs/next/technology/deployment-files/secrets-env.md
+++ b/docs/next/technology/deployment-files/secrets-env.md
@@ -5,7 +5,7 @@ title: secrets.env
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 <Todo>
 

--- a/docs/next/technology/protocols/request-response/airnode.md
+++ b/docs/next/technology/protocols/request-response/airnode.md
@@ -5,7 +5,7 @@ title: Airnode
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Use Airnode to serve one or more APIs to smart contracts (clients). Each Airnode has only one private key, which they use across all chains.
 

--- a/docs/next/technology/protocols/request-response/authorizer.md
+++ b/docs/next/technology/protocols/request-response/authorizer.md
@@ -5,7 +5,7 @@ title: Authorizer
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An authorizer is a contract with the following interface:
 

--- a/docs/next/technology/protocols/request-response/client.md
+++ b/docs/next/technology/protocols/request-response/client.md
@@ -5,7 +5,7 @@ title: Client
 # {{$frontmatter.title}}
 
 <!--TocHeader /-->
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A client is a contract that makes Airnode requests. While making a request, the client refers to a [requester](requester.md) by its [`requesterIndex`](requester.md#requesterIndex), which means "fulfill my request with the [designated wallet](designated-wallet.md) of the requester identified by `requesterIndex`". Doing so requires the client to be [endorsed](endorsement.md) by the said requester.
 

--- a/docs/next/technology/protocols/request-response/designated-wallet.md
+++ b/docs/next/technology/protocols/request-response/designated-wallet.md
@@ -5,7 +5,7 @@ title: Designated wallet
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Each [Airnode](Airnode.md) keeps a designated wallet for each [requester](requester.md).
 [Clients](client.md) [endorsed](endorsement.md) by a requester can specify their requests to be fulfilled by the said requester's designated wallet.

--- a/docs/next/technology/protocols/request-response/endorsement.md
+++ b/docs/next/technology/protocols/request-response/endorsement.md
@@ -5,7 +5,7 @@ title: Endorsement
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A [requester](requester.md) announcing that a [client](client.md) can specify their requests to be fulfilled by the requester's [designated wallets](designated-wallet.md) is called an endorsement.
 This is done by the `requesterAdmin` calling `RequesterStore.sol` with the client contract's address.

--- a/docs/next/technology/protocols/request-response/endpoint.md
+++ b/docs/next/technology/protocols/request-response/endpoint.md
@@ -5,7 +5,7 @@ title: Endpoint
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Airnode serves APIs to blockchains according to [Oracle Integration Specifications (OIS)](../../specifications/ois.md).
 APIs are composed of [operations](../../specifications/ois.md#_4-4-paths), which represent individual functionalities that an API offers. OIS maps each API operation to an [endpoint](../../specifications/ois.md#_5-endpoints), which can be thought of as an Airnode operation. The endpoints that an Airnode will serve over the request–response protocol are listed under [triggers](../../deployment-files/config-json.md#triggers) of [config.json](../../deployment-files/config-json.md).

--- a/docs/next/technology/protocols/request-response/general-structure.md
+++ b/docs/next/technology/protocols/request-response/general-structure.md
@@ -5,7 +5,7 @@ title: General structure
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 The first protocol implemented for Airnode is request–response.
 An Airnode serving the request–response protocol listens for requests, makes the API call specified by the request, and fulfills the request as soon as possible.

--- a/docs/next/technology/protocols/request-response/request.md
+++ b/docs/next/technology/protocols/request-response/request.md
@@ -5,7 +5,7 @@ title: Request
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 When a client makes a request using `Airnode.sol`, it is returned a `requestId`. This `requestId` is a hash of all request parameters and a nonce. This allows Airnode to verify that the request parameters are not tampered with.
 

--- a/docs/next/technology/protocols/request-response/requester.md
+++ b/docs/next/technology/protocols/request-response/requester.md
@@ -5,7 +5,7 @@ title: Requester
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A requester is an entity (individual, business, etc.) whose contracts make requests to [Airnodes](airnode.md).
 These contracts are called [clients](client.md).

--- a/docs/next/technology/protocols/request-response/template.md
+++ b/docs/next/technology/protocols/request-response/template.md
@@ -5,7 +5,7 @@ title: Template
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle request has many parameters.
 It is very common for [clients](client.md) (e.g., a data feed) to make repeated requests with the exact same parameters.

--- a/docs/next/technology/specifications/airnode-abi-specifications.md
+++ b/docs/next/technology/specifications/airnode-abi-specifications.md
@@ -5,7 +5,7 @@ title: Airnode ABI specifications
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 [Contract application binary interface (ABI)](https://docs.soliditylang.org/en/v0.6.12/abi-spec.html) is used to encode different types of data while interacting with Ethereum contracts.
 As a result, both Solidity and modules such as web3.js and ethers.js treat ABI encoding–decoding functionality as a first-class citizen.

--- a/docs/next/technology/specifications/depr-config-json.md
+++ b/docs/next/technology/specifications/depr-config-json.md
@@ -10,7 +10,7 @@ This copy of config.json is deprecated. See <u>[config.json](../deployment-files
 :::
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 `config.json` is the configuration file used for deploying Airnode.
 It is composed of four main sections:

--- a/docs/next/technology/specifications/depr-security-json.md
+++ b/docs/next/technology/specifications/depr-security-json.md
@@ -9,7 +9,7 @@ Is this deprecated? See <u>[secrets.json](../deployment-files/secrets-env.md)</u
 :::
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 `security.json` is the file the deployer uses to push API credentials along with the serverless function.
 

--- a/docs/next/technology/specifications/ois.md
+++ b/docs/next/technology/specifications/ois.md
@@ -5,7 +5,7 @@ title: Oracle Integration Specifications (OIS) 1.0.0
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Setting Oracle Integration Standards](https://medium.com/api3/setting-oracle-integration-standards-ac9104c38f9e) for an overview of OIS.*
 

--- a/docs/next/technology/specifications/reserved-parameters.md
+++ b/docs/next/technology/specifications/reserved-parameters.md
@@ -5,7 +5,7 @@ title: Reserved parameters
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A requester can pass request parameters either by referencing a [template](../protocols/request-response/template.md) that contains them, or as an argument of the request-making methods of [Airnode.sol](../protocols/request-response/general-structure.md#airnodesol).
 In either case, these parameters are encoded in a `bytes`-type variable using [Airnode ABI](airnode-abi-specifications.md).

--- a/docs/pre-alpha/README.md
+++ b/docs/pre-alpha/README.md
@@ -9,7 +9,7 @@ title: What is API?
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 **API3** ([https://api3.org](https://api3.org)) is a collaborative project to deliver traditional API services to smart contract platforms in a decentralized and trust-minimized way. It is governed by a _decentralized autonomous organization_ (DAO), namely the **API3 DAO**. Therefore, its code is open source and its operations are transparent.
 

--- a/docs/pre-alpha/airnode/design-philosophy.md
+++ b/docs/pre-alpha/airnode/design-philosophy.md
@@ -5,7 +5,7 @@ title: Airnode design philosophy
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Airnode: The API gateway for blockchains](https://medium.com/api3/airnode-the-api-gateway-for-blockchains-8b07ff136840) for a high level overview of Airnode.*
 

--- a/docs/pre-alpha/airnode/ethereum-providers.md
+++ b/docs/pre-alpha/airnode/ethereum-providers.md
@@ -4,7 +4,7 @@ title: Ethereum providers
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle node requires access to a blockchain (e.g., Ethereum) node to listen for request events and send transactions to fulfill requests.
 The Airnode model aims to minimize the node operation effort using managed services wherever possible.

--- a/docs/pre-alpha/airnode/implementation.md
+++ b/docs/pre-alpha/airnode/implementation.md
@@ -5,7 +5,7 @@ title: Airnode implementation
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Getting to know Airnode](https://medium.com/api3/getting-to-know-airnode-162e50ea243e) for a technical overview of the software.*
 

--- a/docs/pre-alpha/airnode/specifications/airnode-abi-specifications.md
+++ b/docs/pre-alpha/airnode/specifications/airnode-abi-specifications.md
@@ -5,7 +5,7 @@ title: Airnode ABI specifications
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 [Contract application binary interface (ABI)](https://docs.soliditylang.org/en/v0.6.12/abi-spec.html) is used to encode different types of data while interacting with Ethereum contracts.
 As a result, both Solidity and modules such as web3.js and ethers.js treat ABI encoding–decoding functionality as a first-class citizen.

--- a/docs/pre-alpha/airnode/specifications/config-json.md
+++ b/docs/pre-alpha/airnode/specifications/config-json.md
@@ -5,7 +5,7 @@ title: config.json
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 `config.json` is the configuration file used for deploying Airnode.
 It is composed of four main sections:

--- a/docs/pre-alpha/airnode/specifications/ois.md
+++ b/docs/pre-alpha/airnode/specifications/ois.md
@@ -5,7 +5,7 @@ title: Oracle Integration Specifications (OIS) 1.0.0
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [Setting Oracle Integration Standards](https://medium.com/api3/setting-oracle-integration-standards-ac9104c38f9e) for an overview of OIS.*
 

--- a/docs/pre-alpha/airnode/specifications/reserved-parameters.md
+++ b/docs/pre-alpha/airnode/specifications/reserved-parameters.md
@@ -5,7 +5,7 @@ title: Reserved parameters
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A requester can pass request parameters either by referencing a [template](../../protocols/request-response/template.md) that contains them, or as an argument of the request-making methods of [Airnode.sol](../../protocols/request-response/general-structure.md#airnodesol).
 In either case, these parameters are encoded in a `bytes`-type variable using [Airnode ABI](airnode-abi-specifications.md).

--- a/docs/pre-alpha/airnode/specifications/security-json.md
+++ b/docs/pre-alpha/airnode/specifications/security-json.md
@@ -5,7 +5,7 @@ title: security.json
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 `security.json` is the file the deployer uses to push API credentials along with the serverless function.
 

--- a/docs/pre-alpha/fundamentals/apis.md
+++ b/docs/pre-alpha/fundamentals/apis.md
@@ -5,7 +5,7 @@ title: API (Application programming interface)
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [APIs: The Digital Glue](https://medium.com/api3/apis-the-digital-glue-7ac87566e773) for a more complete background on APIs.*
 

--- a/docs/pre-alpha/fundamentals/dapis.md
+++ b/docs/pre-alpha/fundamentals/dapis.md
@@ -4,7 +4,7 @@ title: dAPI (Decentralized API)
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 We have covered the following:
 

--- a/docs/pre-alpha/fundamentals/decentrally-governed-oracle-networks.md
+++ b/docs/pre-alpha/fundamentals/decentrally-governed-oracle-networks.md
@@ -4,7 +4,7 @@ title: Decentrally-governed oracle networks
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 *See our article, [On DAOs: Decentralized Autonomous Organizations](https://medium.com/api3/on-daos-decentralized-autonomous-organizations-84c00abb89bc) on DAOs and decentralized governance.*
 

--- a/docs/pre-alpha/fundamentals/first-party-oracles.md
+++ b/docs/pre-alpha/fundamentals/first-party-oracles.md
@@ -4,7 +4,7 @@ title: First-party oracles
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle is an agent that acts as an intermediary between a smart contract platform and an API.
 In other words, a decentralized application can use an oracle to call an API.

--- a/docs/pre-alpha/guides/docker/client-image.md
+++ b/docs/pre-alpha/guides/docker/client-image.md
@@ -4,7 +4,7 @@ title: Client image instructions
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 1. Build the Docker image (you can skip this step and fetch the pre-built image)
 ```sh

--- a/docs/pre-alpha/guides/docker/deployer-image.md
+++ b/docs/pre-alpha/guides/docker/deployer-image.md
@@ -5,7 +5,7 @@ title: Deployer image instructions
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 1. Build the Docker image
 ```sh

--- a/docs/pre-alpha/guides/provider/api-integration.md
+++ b/docs/pre-alpha/guides/provider/api-integration.md
@@ -5,7 +5,7 @@ title: API integration
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 To integrate a System X to a System Y, we need to do three things:
 - Specify the interface of System X

--- a/docs/pre-alpha/guides/provider/configuring-airnode.md
+++ b/docs/pre-alpha/guides/provider/configuring-airnode.md
@@ -5,7 +5,7 @@ title: Configuring Airnode
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Users configure their Airnodes by providing a `config.json` and a `security.json` file during deployment/redeployment.
 `config.json` specifies the API–oracle integration specifications in the form of [OIS](../../airnode/specifications/ois.md)es, but also user-specific configuration details.

--- a/docs/pre-alpha/guides/provider/deploying-airnode.md
+++ b/docs/pre-alpha/guides/provider/deploying-airnode.md
@@ -5,7 +5,7 @@ title: Deploying Airnode
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 After [integrating your API](api-integration.md) and [creating the configuration files](configuring-airnode.md), the next step is to deploy your Airnode.
 Airnode comes with a [deployer](https://github.com/api3dao/airnode/tree/pre-alpha/packages/deployer), which uses [Terraform](https://www.terraform.io/) and [Serverless Framework](https://www.serverless.com/) to automate the entire deployment process.

--- a/docs/pre-alpha/guides/provider/setting-authorizers.md
+++ b/docs/pre-alpha/guides/provider/setting-authorizers.md
@@ -5,7 +5,7 @@ title: Setting authorizers
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 We are assuming that you have [configured your Airnode](configuring-airnode.md) (and set `endpointId`s of your endpoints), and [deployed your Airnode](deploying-airnode.md) and received your `providerId` in your receipt file.
 Requesters who know your `providerId` and `endpointId`s should now be able to make requests to your endpoints.

--- a/docs/pre-alpha/guides/requester/creating-a-requester.md
+++ b/docs/pre-alpha/guides/requester/creating-a-requester.md
@@ -4,7 +4,7 @@ title: Creating a requester
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Each requester needs to create a requester record, and get assigned a requester index.
 This is fairly early, using [@api3/airnode-admin](https://github.com/api3dao/airnode/tree/pre-alpha/packages/admin#create-requester).

--- a/docs/pre-alpha/guides/requester/developing-a-client-contract.md
+++ b/docs/pre-alpha/guides/requester/developing-a-client-contract.md
@@ -5,7 +5,7 @@ title: Developing a client contract
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A [client](../../protocols/request-response/client.md) is a contract that makes requests to [providers](../../protocols/request-response/provider.md) using the [Airnode.sol](../../protocols/request-response/general-structure.md#airnode-sol) contract that implements the protocol.
 A client is [endorsed](../../protocols/request-response/endorsement.md) by a [requester](../../protocols/request-response/requester.md), which means that it can specify its request to be fulfilled by the respective requester's [designated wallet](../../protocols/request-response/designated-wallet.md).

--- a/docs/pre-alpha/guides/smart-contracts/is-my-platform-compatible.md
+++ b/docs/pre-alpha/guides/smart-contracts/is-my-platform-compatible.md
@@ -5,7 +5,7 @@ title: Is my platform compatible?
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 We are receiving an overwhelming amount of demand by teams of smart contract platforms and decentralized applications built on these about integrating Airnode to gain access to API data and services.
 These guides are for you to be able to self-serve to assess the feasibility of an integration, and even prototype the integration yourself.

--- a/docs/pre-alpha/guides/smart-contracts/self-serve-integration.md
+++ b/docs/pre-alpha/guides/smart-contracts/self-serve-integration.md
@@ -5,7 +5,7 @@ title: Self-serve integration
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Assuming you have determined that your platform [is compatible](is-my-platform-compatible.md), you can attempt to do the integration yourself by following the steps below.
 

--- a/docs/pre-alpha/introduction/contributing.md
+++ b/docs/pre-alpha/introduction/contributing.md
@@ -4,7 +4,7 @@ title: Contributing
 
 # {{$frontmatter.title}}
 
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 (To the API3 DAO as a technical member)
 

--- a/docs/pre-alpha/protocols/request-response/authorizer.md
+++ b/docs/pre-alpha/protocols/request-response/authorizer.md
@@ -5,7 +5,7 @@ title: Authorizer
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An authorizer is a contract with the following interface:
 

--- a/docs/pre-alpha/protocols/request-response/client.md
+++ b/docs/pre-alpha/protocols/request-response/client.md
@@ -5,7 +5,7 @@ title: Client
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A client is a contract that makes Airnode requests.
 While making a request, the client refers to a [requester](requester.md) by its [`requesterIndex`](requester.md#requesterIndex), which means "fulfill my request with the [designated wallet](designated-wallet.md) of the requester identified by `requesterIndex`".

--- a/docs/pre-alpha/protocols/request-response/designated-wallet.md
+++ b/docs/pre-alpha/protocols/request-response/designated-wallet.md
@@ -5,7 +5,7 @@ title: Designated wallet
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Each [provider](provider.md) keeps a designated wallet for each [requester](requester.md).
 [Clients](client.md) [endorsed](endorsement.md) by a requester can specify their requests to be fulfilled by the said requester's designated wallet.

--- a/docs/pre-alpha/protocols/request-response/endorsement.md
+++ b/docs/pre-alpha/protocols/request-response/endorsement.md
@@ -5,7 +5,7 @@ title: Endorsement
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A [requester](requester.md) announcing that a [client](client.md) can specify their requests to be fulfilled by the requester's [designated wallets](designated-wallet.md) is called an endorsement.
 This is done by the `requesterAdmin` calling `RequesterStore.sol` with the client contract's address.

--- a/docs/pre-alpha/protocols/request-response/endpoint.md
+++ b/docs/pre-alpha/protocols/request-response/endpoint.md
@@ -5,7 +5,7 @@ title: Endpoint
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 Airnode serves APIs to blockchains according to [Oracle Integration Specifications (OIS)](../../airnode/specifications/ois.md).
 APIs are composed of [operations](../../airnode/specifications/ois.md#_4-4-paths), which represent individual functionalities that an API offers.

--- a/docs/pre-alpha/protocols/request-response/general-structure.md
+++ b/docs/pre-alpha/protocols/request-response/general-structure.md
@@ -5,7 +5,7 @@ title: General structure
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 The first protocol implemented for Airnode is request–response.
 An Airnode serving the request–response protocol listens for requests, makes the API call specified by the request, and fulfills the request as soon as possible.

--- a/docs/pre-alpha/protocols/request-response/provider.md
+++ b/docs/pre-alpha/protocols/request-response/provider.md
@@ -5,7 +5,7 @@ title: Provider
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A provider is an entity (individual, business, etc.) that operates an Airnode to serve one or more APIs to smart contracts.
 Each provider has only one private key, which they use across all chains.

--- a/docs/pre-alpha/protocols/request-response/request.md
+++ b/docs/pre-alpha/protocols/request-response/request.md
@@ -5,7 +5,7 @@ title: Request
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 When a client makes a request using `Airnode.sol`, it is returned a `requestId`.
 This `requestId` is a hash of all request parameters and a nonce.

--- a/docs/pre-alpha/protocols/request-response/requester.md
+++ b/docs/pre-alpha/protocols/request-response/requester.md
@@ -5,7 +5,7 @@ title: Requester
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 A requester is an entity (individual, business, etc.) whose contracts make requests to [providers](provider.md).
 These contracts are called [clients](client.md).

--- a/docs/pre-alpha/protocols/request-response/template.md
+++ b/docs/pre-alpha/protocols/request-response/template.md
@@ -5,7 +5,7 @@ title: Template
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 An oracle request has many parameters.
 It is very common for [clients](client.md) (e.g., a data feed) to make repeated requests with the exact same parameters.

--- a/docs/pre-alpha/tutorials/airnode-starter.md
+++ b/docs/pre-alpha/tutorials/airnode-starter.md
@@ -5,7 +5,7 @@ title: Airnode starter
 # {{$frontmatter.title}}
 
 <TocHeader />
-[[TOC]]
+<TOC class="table-of-contents" :include-level="[2,3]" />
 
 > A starter project for deploying an Airnode and making requests to it
 


### PR DESCRIPTION
The VuePress native TOC was not playing nicely with the browser's history. Users cannot "go back" with the back button to a previous TOC selection. Probably because the TOC is just a bunch of links that are getting registered with the Vue router. 

The community plugin does seem to take advantage of the Vue Router and the history stack is working. I noticed that this plugin was produced by the VuePress team and then handed over to the community for support. A look at the code shows it would be easy to maintain.