### PR TITLE
Fix links with anchors - issue - 76

### DIFF
--- a/docs/next/grp-providers/guides/docker/deployer-image.md
+++ b/docs/next/grp-providers/guides/docker/deployer-image.md
@@ -14,7 +14,7 @@ docker build . -t api3/airnode-deployer:pre-alpha
 
 2. Ensure that your `.env` file looks like [.env.example](https://github.com/api3dao/airnode/blob/pre-alpha/packages/deployer/.env.example) and is the current working directory.
 
-3. If you will be running [deploy-first-time](#deploy-first-time) or [redeploy](#redeploy), your `config.json` and `security.json` must be in the current working directory.
+3. If you will be running [deploy-first-time](deployer-image.md#deploy-first-time) or [redeploy](deployer-image.md#redeploy), your `config.json` and `security.json` must be in the current working directory.
 (They are also needed for other commands temporarily.)
 
 4. Run the image with one of the following commands:

--- a/docs/next/grp-providers/guides/provider/api-integration.md
+++ b/docs/next/grp-providers/guides/provider/api-integration.md
@@ -5,7 +5,7 @@ title: API Integration
 # {{$frontmatter.title}}
 
 <TocHeader />
-<TOC class="table-of-contents" :include-level="[2,3]" />
+<TOC class="table-of-contents" :include-level="[2,4]" />
 
 A successful integration of an API with an Airnode requires the mapping of each other's interface. This is accomplished using an OIS ([Oracle Integration Specifications](../../../technology/specifications/ois.md)) json object, found in the config.json file, that is designed to follow three basic steps.
 
@@ -176,7 +176,7 @@ After specifying the path and method of an API operation, the final step is to s
 Each parameter is an object in the `apiSpecifications.paths.{PATH}.{METHOD}.parameters` array, with the fields `in` and `name`.
 `in` tells where the parameter goes in the HTTP request, and `name` tells the name that the parameter value will be sent under.
 
-It is not necessary to specify all API operation parameters, but only the ones the on-chain requester will need to be able to provide (see Airnode endpoint [parameters](#parameters)), and the ones that you want to hard-code a value for (see Airnode endpoint [fixed operation parameters](#fixedoperationparameters)).
+It is not necessary to specify all API operation parameters, but only the ones the on-chain requester will need to be able to provide (see Airnode endpoint [parameters](api-integration.md#parameters)), and the ones that you want to hard-code a value for (see Airnode endpoint [fixed operation parameters](api-integration.md#fixedoperationparameters)).
 
 Currently Airnode supports the following parameter types. For POST methods use the type `query` for requestBody parameters, Airnode will convert all `query` types to `requestBody` when calling the API operation.
 

--- a/docs/next/grp-providers/guides/provider/deploying-airnode.md
+++ b/docs/next/grp-providers/guides/provider/deploying-airnode.md
@@ -37,7 +37,7 @@ Deployment" needs to be updated when vrs 0.1.0 is ready. Not sure which Airnode 
 
 </Todo>
 
-Get the `config.json` and `security.json` files you have created while [configuring your Airnode](configuring-airnode.md), your `.env` file with your [cloud provider credentials](#creating-cloud-credentials), and place these three files in the same directory.
+Get the `config.json` and `security.json` files you have created while [configuring your Airnode](configuring-airnode.md), your `.env` file with your [cloud provider credentials](deploying-airnode.md#creating-cloud-credentials), and place these three files in the same directory.
 Then, in this same directory, run the following command (if you are on Windows, use CMD, replace `\` with `^`, `$(pwd)` with `%cd%`):
 
 ```sh

--- a/docs/next/technology/specifications/ois.md
+++ b/docs/next/technology/specifications/ois.md
@@ -16,11 +16,11 @@ These prepopulated fields are expected to be reviewed and customized by the inte
 
 *All URLs are absolute (i.e., [relative URLs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#relative-references-in-urls) are not supported).*
 
-- [`oisFormat`](#1-oisFormat)
-- [`title`](#2-title)
-- [`version`](#3-version)
-- [`apiSpecifications`](#4-apiSpecifications)
-- [`endpoints`](#5-endpoints)
+- [`oisFormat`](ois.md#_1-oisformat)
+- [`title`](ois.md#_2-title)
+- [`version`](ois.md#_3-version)
+- [`apiSpecifications`](ois.md#_4-apispecifications)
+- [`endpoints`](ois.md#_5-endpoints)
 
 ```json
 {
@@ -54,10 +54,10 @@ OAS equivalent: `info.title`
 
 (Required) An object specifying the API with the following fields:
 
-- [`servers`](#41-servers)
-- [`components`](#42-components)
-- [`security`](#43-security)
-- [`paths`](#44-paths)
+- [`servers`](ois.md#_4-1-servers)
+- [`components`](ois.md#_4-2-components)
+- [`security`](ois.md#_4-3-security)
+- [`paths`](ois.md#_4-4-paths)
 
 ```json
 {
@@ -105,10 +105,10 @@ OAS equivalent: `servers.0` (raise warning during conversion if `servers` has mu
 
 (Required) An object where security schemes can be found under `securitySchemes.{securitySchemeName}` with the following elements:
 
-- [`type`](#421-type)
-- [`name`](#422-name)
-- [`in`](#423-in)
-- [`scheme`](#424-scheme)
+- [`type`](ois.md#_4-2-1-type)
+- [`name`](ois.md#_4-2-2-name)
+- [`in`](ois.md#_4-2-3-in)
+- [`scheme`](ois.md#_4-2-4-scheme)
 
 #### 4.2.1. `type`
 
@@ -166,8 +166,8 @@ OAS equivalent: `security`, or `security.0` if `security` is a list (raise warni
 
 (Required) A list of operation parameters, each with the following fields:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 ##### 4.4.1.1. `name`
 
@@ -187,14 +187,14 @@ OAS equivalent: `paths.{path}.{method}.parameters.{#}.in`
 
 (Required) A list of objects, each specifying an oracle endpoint with the following fields:
 
-- [`name`](#51-name)
-- [`operation`](#52-operation)
-- [`fixedOperationParameters`](#53-fixedOperationParameters)
-- [`reservedParameters`](#54-reservedParameters)
-- [`parameters`](#55-parameters)
-- [`summary`*](#56-summary*)
-- [`description`*](#57-description*)
-- [`externalDocs`*](#58-externalDocs*)
+- [`name`](ois.md#_5-1-name)
+- [`operation`](ois.md#_5-2-operation)
+- [`fixedOperationParameters`](ois.md#_5-3-fixedoperationparameters)
+- [`reservedParameters`](ois.md#_5-4-reservedparameters)
+- [`parameters`](ois.md#_5-5-parameters)
+- [`summary`*](ois.md#_5-6-summary)
+- [`description`*](ois.md#_5-7-description)
+- [`externalDocs`*](ois.md#_5-8-externaldocs)
 
 ```json
 [
@@ -250,8 +250,8 @@ OAS equivalent: `paths.{path}.{method}.operationId` of the corresponding operati
 
 (Required) An object that refers to an operation defined in `apiSpecifications.paths`, has the following elements:
 
-- [`path`](#521-path)
-- [`method`](#522-method)
+- [`path`](ois.md#_5-2-1-path)
+- [`method`](ois.md#_5-2-2-method)
 
 #### 5.2.1. `path`
 
@@ -271,15 +271,15 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 
 (Required) A list of objects specifying fixed operation parameters. While required, the fixedOperationParameters array can be left empty. Each object has the following elements:
 
-- [`operationParameter`](#531-operationParameter)
-- [`value`](#532-value)
+- [`operationParameter`](ois.md#_5-3-1-operationparameter)
+- [`value`](ois.md#_5-3-2-value)
 
 #### 5.3.1. `operationParameter`
 
 (Required) An object that refers to an operation parameter, has the following elements:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 #### 5.3.2. `value`
 
@@ -290,9 +290,9 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 (Optional) A list of objects that specify reserved endpoint parameters that do not map to operation parameters, but used for special purposes by the oracle node.
 Each object has the following elements:
 
-- [`name`](#541-name)
-- [`fixed`](#542-fixed)
-- [`default`](#543-default)
+- [`name`](ois.md#_5-4-1-name)
+- [`fixed`](ois.md#_5-4-2-fixed)
+- [`default`](ois.md#_5-4-3-default)
 
 #### 5.4.1. `name`
 
@@ -315,19 +315,19 @@ Used when no value is provided.
 (Optional) A list of objects that specify endpoint parameters that map to operation parameters.
 Each object has the following elements:
 
-- [`operationParameter`](#551-operationParameter)
-- [`name`](#552-name)
-- [`default`](#553-default)
-- [`description`*](#554-description*)
-- [`required`*](#555-required*)
-- [`example`*](#556-example*)
+- [`operationParameter`](ois.md#_5-5-1-operationparameter)
+- [`name`](ois.md#_5-5-2-name)
+- [`default`](ois.md#_5-5-3-default)
+- [`description`*](ois.md#_5-5-4-description)
+- [`required`*](ois.md#_5-5-5-required)
+- [`example`*](ois.md#_5-5-6-example)
 
 #### 5.5.1. `operationParameter`
 
 (Required) An object that refers to an operation parameter, has the following elements:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 #### 5.5.2. `name`
 

--- a/docs/next/technology/specifications/reserved-parameters.md
+++ b/docs/next/technology/specifications/reserved-parameters.md
@@ -11,8 +11,8 @@ A requester can pass request parameters either by referencing a [template](../pr
 In either case, these parameters are encoded in a `bytes`-type variable using [Airnode ABI](airnode-abi-specifications.md).
 There are two types of parameters:
 
-1. [Endpoint parameters](https://api3dao.github.io/api3-docs/pre-alpha/airnode/specifications/ois.html#_5-5-parameters) mapped to API operation parameters
-1. [Reserved parameters](https://api3dao.github.io/api3-docs/pre-alpha/airnode/specifications/ois.html#_5-4-reservedparameters)
+1. [Endpoint parameters](ois.md#_5-5-parameters) mapped to API operation parameters
+2. [Reserved parameters](ois.md#_5-4-reservedparameters)
 
 Reserved parameters signal to the provider to perform a specific operation while fulfilling the request.
 Reserved parameter names start with `_`.

--- a/docs/pre-alpha/airnode/specifications/ois.md
+++ b/docs/pre-alpha/airnode/specifications/ois.md
@@ -16,11 +16,11 @@ These prepopulated fields are expected to be reviewed and customized by the inte
 
 *All URLs are absolute (i.e., [relative URLs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#relative-references-in-urls) are not supported).*
 
-- [`oisFormat`](#1-oisFormat)
-- [`title`](#2-title)
-- [`version`](#3-version)
-- [`apiSpecifications`](#4-apiSpecifications)
-- [`endpoints`](#5-endpoints)
+- [`oisFormat`](ois.md#_1-oisformat)
+- [`title`](ois.md#_2-title)
+- [`version`](ois.md#_3-version)
+- [`apiSpecifications`](ois.md#_4-apispecifications)
+- [`endpoints`](ois.md#_5-endpoints)
 
 ```json
 {
@@ -54,10 +54,10 @@ OAS equivalent: `info.title`
 
 (Required) An object specifying the API with the following fields:
 
-- [`servers`](#41-servers)
-- [`components`](#42-components)
-- [`security`](#43-security)
-- [`paths`](#44-paths)
+- [`servers`](ois.md#_4-1-servers)
+- [`components`](ois.md#_4-2-components)
+- [`security`](ois.md#_4-3-security)
+- [`paths`](ois.md#_4-4-paths)
 
 ```json
 {
@@ -105,10 +105,10 @@ OAS equivalent: `servers.0` (raise warning during conversion if `servers` has mu
 
 (Required) An object where security schemes can be found under `securitySchemes.{securitySchemeName}` with the following elements:
 
-- [`type`](#421-type)
-- [`name`](#422-name)
-- [`in`](#423-in)
-- [`scheme`](#424-scheme)
+- [`type`](ois.md#_4-2-1-type)
+- [`name`](ois.md#_4-2-2-name)
+- [`in`](ois.md#_4-2-3-in)
+- [`scheme`](ois.md#_4-2-4-scheme)
 
 #### 4.2.1. `type`
 
@@ -160,14 +160,14 @@ OAS equivalent: `security`, or `security.0` if `security` is a list (raise warni
 
 (Required) An object where operations can be found under `{path}.{method}` with the following elements:
 
-- [`parameters`](#441-parameters)
+- [`parameters`](ois.md#_4-4-1-parameters)
 
 #### 4.4.1. `parameters`
 
 (Required) A list of operation parameters, each with the following fields:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 ##### 4.4.1.1. `name`
 
@@ -187,14 +187,14 @@ OAS equivalent: `paths.{path}.{method}.parameters.{#}.in`
 
 (Required) A list of objects, each specifying an oracle endpoint with the following fields:
 
-- [`name`](#51-name)
-- [`operation`](#52-operation)
-- [`fixedOperationParameters`](#53-fixedOperationParameters)
-- [`reservedParameters`](#54-reservedParameters)
-- [`parameters`](#55-parameters)
-- [`summary`*](#56-summary*)
-- [`description`*](#57-description*)
-- [`externalDocs`*](#58-externalDocs*)
+- [`name`](ois.md#_5-1-name)
+- [`operation`](ois.md#_5-2-operation)
+- [`fixedOperationParameters`](ois.md#_5-3-fixedoperationparameters)
+- [`reservedParameters`](ois.md#_5-4-reservedparameters)
+- [`parameters`](ois.md#_5-5-parameters)
+- [`summary`*](ois.md#_5-6-summary)
+- [`description`*](ois.md#_5-7-description)
+- [`externalDocs`*](ois.md#_5-8-externaldocs)
 
 ```json
 [
@@ -250,8 +250,8 @@ OAS equivalent: `paths.{path}.{method}.operationId` of the corresponding operati
 
 (Required) An object that refers to an operation defined in `apiSpecifications.paths`, has the following elements:
 
-- [`path`](#521-path)
-- [`method`](#522-method)
+- [`path`](ois.md#_5-2-1-path)
+- [`method`](ois.md#_5-2-2-method)
 
 #### 5.2.1. `path`
 
@@ -271,15 +271,15 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 
 (Required) A list of objects specifying fixed operation parameters. While required, the fixedOperationParameters array can be left empty. Each object has the following elements:
 
-- [`operationParameter`](#531-operationParameter)
-- [`value`](#532-value)
+- [`operationParameter`](ois.md#_5-3-1-operationparameter)
+- [`value`](ois.md#_5-3-2-value)
 
 #### 5.3.1. `operationParameter`
 
 (Required) An object that refers to an operation parameter, has the following elements:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 #### 5.3.2. `value`
 
@@ -290,9 +290,9 @@ OAS equivalent: The `{method}` parameter in the `paths.{path}.{method}` for the 
 (Optional) A list of objects that specify reserved endpoint parameters that do not map to operation parameters, but used for special purposes by the oracle node.
 Each object has the following elements:
 
-- [`name`](#541-name)
-- [`fixed`](#542-fixed)
-- [`default`](#543-default)
+- [`name`](ois.md#_5-4-1-name)
+- [`fixed`](ois.md#_5-4-2-fixed)
+- [`default`](ois.md#_5-4-3-default)
 
 #### 5.4.1. `name`
 
@@ -315,19 +315,19 @@ Used when no value is provided.
 (Optional) A list of objects that specify endpoint parameters that map to operation parameters.
 Each object has the following elements:
 
-- [`operationParameter`](#551-operationParameter)
-- [`name`](#552-name)
-- [`default`](#553-default)
-- [`description`*](#554-description*)
-- [`required`*](#555-required*)
-- [`example`*](#556-example*)
+- [`operationParameter`](ois.md#_5-5-1-operationparameter)
+- [`name`](ois.md#_5-5-2-name)
+- [`default`](ois.md#_5-5-3-default)
+- [`description`*](ois.md#_5-5-4-description)
+- [`required`*](ois.md#_5-5-5-required)
+- [`example`*](ois.md#_5-5-6-example)
 
 #### 5.5.1. `operationParameter`
 
 (Required) An object that refers to an operation parameter, has the following elements:
 
-- [`name`](#4411-name)
-- [`in`](#4412-in)
+- [`name`](ois.md#_4-4-1-1-name)
+- [`in`](ois.md#_4-4-1-2-in)
 
 #### 5.5.2. `name`
 

--- a/docs/pre-alpha/airnode/specifications/reserved-parameters.md
+++ b/docs/pre-alpha/airnode/specifications/reserved-parameters.md
@@ -11,8 +11,8 @@ A requester can pass request parameters either by referencing a [template](../..
 In either case, these parameters are encoded in a `bytes`-type variable using [Airnode ABI](airnode-abi-specifications.md).
 There are two types of parameters:
 
-1. [Endpoint parameters](https://api3dao.github.io/api3-docs/pre-alpha/airnode/specifications/ois.html#_5-5-parameters) mapped to API operation parameters
-1. [Reserved parameters](https://api3dao.github.io/api3-docs/pre-alpha/airnode/specifications/ois.html#_5-4-reservedparameters)
+1. [Endpoint parameters](ois.md#_5-5-parameters) mapped to API operation parameters
+2. [Reserved parameters](ois.md#_5-4-reservedparameters)
 
 Reserved parameters signal to the provider to perform a specific operation while fulfilling the request.
 Reserved parameter names start with `_`.

--- a/docs/pre-alpha/guides/docker/deployer-image.md
+++ b/docs/pre-alpha/guides/docker/deployer-image.md
@@ -14,7 +14,7 @@ docker build . -t api3/airnode-deployer:pre-alpha
 
 2. Ensure that your `.env` file looks like [.env.example](https://github.com/api3dao/airnode/blob/pre-alpha/packages/deployer/.env.example) and is the current working directory.
 
-3. If you will be running [deploy-first-time](#deploy-first-time) or [redeploy](#redeploy), your `config.json` and `security.json` must be in the current working directory.
+3. If you will be running [deploy-first-time](deployer-image.md#deploy-first-time) or [redeploy](deployer-image.md#redeploy), your `config.json` and `security.json` must be in the current working directory.
 (They are also needed for other commands temporarily.)
 
 4. Run the image with one of the following commands:

--- a/docs/pre-alpha/guides/provider/api-integration.md
+++ b/docs/pre-alpha/guides/provider/api-integration.md
@@ -113,7 +113,7 @@ After specifying the path and method of an operation, the final step is to speci
 Each parameter is an object in `apiSpecifications.path.{PATH}.{METHOD}.parameters`, with the fields `in` and `name`.
 `in` tells where the parameter goes in the HTTP request to the API, and `name` tells the name that the parameter value will be sent under.
 
-Note that you do not have to specify all operation parameters, but only the ones that you want the on-chain requester to be able to provide (see [endpoint parameters](#parameters)), and the ones that you want to hardcode a value to (see [fixed operation parameters](#fixedoperationparameters)).
+Note that you do not have to specify all operation parameters, but only the ones that you want the on-chain requester to be able to provide (see [endpoint parameters](api-integration.md#parameters)), and the ones that you want to hardcode a value to (see [fixed operation parameters](api-integration.md#fixedoperationparameters)).
 
 ### Security schemes
 
@@ -145,7 +145,7 @@ Then, it is the integrator's job to define what this service is.
 
 For example, if your API operation returns an asset price given its ticker (e.g., `BTC`), you can specify the endpoint such that the requester provides the ticker as a parameter.
 The resulting endpoint would be a general one that returns prices for any kind of asset.
-On the other hand, you can hardcode `BTC` as the asset whose price will be returned (using [fixed operation parameters](#fixedoperationparameters)), which would make your endpoint a specific one that only returns the BTC price.
+On the other hand, you can hardcode `BTC` as the asset whose price will be returned (using [fixed operation parameters](api-integration.md#fixedoperationparameters)), which would make your endpoint a specific one that only returns the BTC price.
 
 The recommended endpoint definition pattern is to create an endpoint for each API operation, and allow the requesters to provide all operation parameters themselves.
 This results in optimal flexibility, and essentially allows the requesters to use the entire API functionality on-chain.

--- a/docs/pre-alpha/guides/provider/deploying-airnode.md
+++ b/docs/pre-alpha/guides/provider/deploying-airnode.md
@@ -36,7 +36,7 @@ These credentials can be used to gain access to your Airnode's private key.
 
 ## Deployment
 
-Get the `config.json` and `security.json` files you have created while [configuring your Airnode](configuring-airnode.md), your `.env` file with your [cloud provider credentials](#creating-cloud-credentials), and place these three files in the same directory.
+Get the `config.json` and `security.json` files you have created while [configuring your Airnode](configuring-airnode.md), your `.env` file with your [cloud provider credentials](deploying-airnode.md#creating-cloud-credentials), and place these three files in the same directory.
 Then, in this same directory, run the following command (if you are on Windows, use CMD, replace `\` with `^`, `$(pwd)` with `%cd%`):
 
 ```sh


### PR DESCRIPTION
Old anchors from GitBook are lingering. VuePress has different behavior.

**Anchors as related to header element in Markdown**
- Spaces must be replaced with a dash.
- When starting with 0-9, must be proceeded with an underscore.
- Periods replaced with a dash.
- A period/space combination replaced with a single dash.
- Asterisks are ignored so omit them.
- Use lowercase.
- Anchors must be proceeded with the file name (myfile.md#anchor) using the markdown extension otherwise go back on the browser history will not work.