### PR TITLE
Redirect timer will not go away

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -64,7 +64,7 @@ module.exports = {
   },
   plugins: 
   [   
-    ['@vuepress/html-redirect', {duration: 0}],
+    ['@vuepress/html-redirect', {countdown: 0}],
     ['vuepress-plugin-table-of-contents'],
     ['vue-pdf'],
     ['@vuepress/medium-zoom'],


### PR DESCRIPTION
The docs from the plugin on NPM are wrong. The repo says use countdown = 0