### PR TITLE
Update the community nav links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The API connectivity problem is in essence an ecosystem building problem, more s
 
 **Website:** https://api3.org/
 
-**Telegram (for community):** https://t.me/API3DAO
+**Community Forum:** https://forum.api3.org/
 
-**Discord (for contributors):** https://discord.gg/qnRrcfnm5W
+**Community Chat:** https://discord.gg/qnRrcfnm5W
 
 **Medium publication of the DAO:** https://medium.com/api3
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -22,8 +22,8 @@ module.exports = {
     displayAllHeaders: false,
     logo: '/img/logo.png',
     nav: [
-      { text: 'Discord (Dev)', link: 'https://discord.gg/qnRrcfnm5W' },
-      { text: 'Telegram (Chat)', link: 'https://t.me/API3DAO' },
+      { text: 'Discord', link: 'https://discord.gg/qnRrcfnm5W' },
+      { text: 'Forum', link: 'https://forum.api3.org/' },
       { text: 'GitHub', link: 'https://github.com/api3dao/api3-docs' },
     ],
     sidebar: {'/next/':require(`../next/sidebar.js`),

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -70,11 +70,11 @@ You can find all our blog posts on our [Medium page here](https://medium.com/api
 :::
 
 ::: tab Communities
-Join the API3 community on the following services.  
+Join the API3 community on the following services.
 
-Community Chat on [Telegram](https://t.me/API3DAO)
+Community Forum on [Discourse](https://forum.api3.org/)
 
-Developer Chat on [Discord](https://discord.gg/qnRrcfnm5W)
+Community Chat on [Discord](https://discord.gg/qnRrcfnm5W)
 
 [YouTube Channel](https://www.youtube.com/channel/UCCpUthOhahxjdeX9T7t7nJQ)
 :::
@@ -95,7 +95,7 @@ Please feel free to contribute to any API3 GitHub repositories.
 
 ## Contributing
 
-At **API3** we are open to any proposals and improvements. Please feel free to contribute. 
+At **API3** we are open to any proposals and improvements. Please feel free to contribute.
 
 * opening issues
 * making pull requests

--- a/docs/pre-alpha/README.md
+++ b/docs/pre-alpha/README.md
@@ -72,9 +72,9 @@ You can find all our blog posts on our [Medium page here](https://medium.com/api
 ::: tab Communities
 Join the API3 community on the following services.  
 
-Community Chat on [Telegram](https://t.me/API3DAO)
+Community Forum on [Discourse](https://forum.api3.org/)
 
-Developer Chat on [Discord](https://discord.gg/qnRrcfnm5W)
+Community Chat on [Discord](https://discord.gg/qnRrcfnm5W)
 
 [YouTube Channel](https://www.youtube.com/channel/UCCpUthOhahxjdeX9T7t7nJQ)
 :::
@@ -95,7 +95,7 @@ Please feel free to contribute to any API3 GitHub repositories.
 
 ## Contributing
 
-At **API3** we are open to any proposals and improvements. Please feel free to contribute. 
+At **API3** we are open to any proposals and improvements. Please feel free to contribute.
 
 * opening issues
 * making pull requests


### PR DESCRIPTION
We're deemphasizing TG as a place to send people and promoting our owned channels such as the forum and discord.