### PR TITLE
AN-86 Airnode BIP 44 wallet

### DIFF
--- a/docs/.vuepress/components/SponsorWalletWarning.vue
+++ b/docs/.vuepress/components/SponsorWalletWarning.vue
@@ -13,11 +13,11 @@
       <div style="color:#b29400;font-weight:600;font-size:medium;">
         Sponsor Wallets
       </div>
-      <div style="padding-top:8px;">Sponsors should not fund a sponsor wallet with 
+      <div style="padding-top:8px;">Sponsors should not fund a <code>sponsor-wallet</code> with 
         more then they can trust the Airnode with, as the Airnode controls the private key 
         to the sponsor wallet. The deployer of such Airnode undertakes no 
         custody obligations, and the risk of loss or misuse of any excess 
-        funds sent to the sponsor wallet remains with the sponsor.
+        funds sent to the <code>sponsor-wallet</code> remains with the sponsor.
       </div>
 
   </div>

--- a/docs/.vuepress/components/TitleSpan.vue
+++ b/docs/.vuepress/components/TitleSpan.vue
@@ -1,0 +1,37 @@
+<!--
+-->
+
+<template>
+  <div id="title-span" :style="cssVars">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'title-span',
+    props: ['left'],
+    computed: {
+      cssVars () {
+        return{
+          /* variables you want to pass to css */
+          '--left': this.left+'px',
+        }
+      }
+    }
+  }
+</script>
+
+/* https://stackoverflow.com/questions/42872002/in-vue-js-component-how-to-use-props-in-css */
+<style scoped>
+  #title-span{
+    opacity: 0.5;
+    width:300px;
+    margin-left:var(--left);
+    color:green;
+    margin-top:-80px;
+    margin-bottom:44px;
+    transform: rotate(-10deg);
+    font-weight:900;
+  }
+</style>

--- a/docs/next/grp-developers/call-an-airnode.md
+++ b/docs/next/grp-developers/call-an-airnode.md
@@ -37,14 +37,14 @@ import "@api3/airnode-protocol/contracts/AirnodeRrpClient.sol";
 
 contract MyContract is AirnodeRrpClient {
   ...
-  constructor (address airnodeAddress)
+  constructor (address airnodeRrpAddress)
       public
-      AirnodeClient(airnodeAddress)
+      AirnodeClient(airnodeRrpAddress)
   {}
   ...
 }
 ```
-Note the constructor parameter `airnodeAddress` which is the public address of the AirnodeRrp.sol protocol contract on the blockchain you wish to use. It is used by AirnodeRrpClient.sol to point itself to AirnodeRrp.sol. See the the list of available addresses below.
+Note the constructor parameter `airnodeRrpAddress` which is the public address of the AirnodeRrp.sol protocol contract on the blockchain you wish to use. It is used by AirnodeRrpClient.sol to point itself to AirnodeRrp.sol. See the the list of available addresses below.
 
 > <ChainsSupported :version="'0.1.0'" />
 
@@ -63,9 +63,9 @@ contract MyContract is AirnodeRrpClient {
   mapping(bytes32 => bool) public incomingFulfillments;
   mapping(bytes32 => int256) public fulfilledData;
 
-  constructor (address airnodeAddress)
+  constructor (address airnodeRrpAddress)
       public
-      AirnodeClient(airnodeAddress)
+      AirnodeClient(airnodeRrpAddress)
   {}
 
   function callTheAirnode(
@@ -152,9 +152,9 @@ contract MyContract is AirnodeRrpClient {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor (address airnodeAddress)
+    constructor (address airnodeRrpAddress)
         public
-        AirnodeClient(airnodeAddress)
+        AirnodeClient(airnodeRrpAddress)
     {}
 
     function callTheAirnode(

--- a/docs/next/reference/protocols/request-response/airnode.md
+++ b/docs/next/reference/protocols/request-response/airnode.md
@@ -3,7 +3,8 @@ title: Airnode
 ---
 
 # {{$frontmatter.title}}
-<div style="width:300px;margin-left:125px;color:green;margin-top:-80px;margin-bottom:44px;transform: rotate(-10deg);font-weight:900;">Concepts and<br/>Definitions</div>
+
+<TitleSpan left=126>Concepts and<br/>Definitions</TitleSpan>
 
 <TocHeader />
 <TOC class="table-of-contents" :include-level="[2,3]" />
@@ -14,13 +15,12 @@ Use Airnode to serve one or more APIs to smart contracts (requesters). An Airnod
 
 An Airnode is identified by the default address of a BIP 44 wallet (with the path m/44'/60'/0'/0/0). 
 
-To accomplish this an Airnode is assigned a mnemonic which is used to derived a wallet, known as the `airnode-wallet`. The wallet's default address becomes the Airnode's identifier, know as the `airnodeAddress`.  The `airnodeAddress` is used to identify the Airnode across all chains.
-
+To accomplish this an Airnode is assigned a mnemonic which is used to derived a wallet, known as the `airnode-wallet`. The wallet's default address becomes the Airnode's identifier, know as the `airnodeAddress` which is used to identify the Airnode across all chains.
 
 The process by which this happens is simple:
 
-- The API provider uses the [deployer's](../../deployer-commands.md#deploy) `deploy` command to create a new Airnode, with or without supplying a mnemonic.
-- `deploy` uses the supplied mnemonic (or generates one if not supplied) to generate the `airnode-wallet`.
+- The API provider uses the [deployer's](../../deployer-commands.md#deploy) `deploy` command to create a new Airnode and supplies a mnemonic defined in the config.json as `nodeSettings.airnodeWalletMnemonic`.
+- `deploy` uses the supplied mnemonic to generate the `airnode-wallet`.
 - `deploy` uses the default address of the `airnode-wallet` as the `airnodeAddress`.
 - `deploy` returns output which includes the `airnodeAddress`.
 

--- a/docs/next/reference/protocols/request-response/requester.md
+++ b/docs/next/reference/protocols/request-response/requester.md
@@ -7,7 +7,7 @@ title: Requester
 <!--TocHeader /-->
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
-A requester is a contract that makes Airnode requests. While making a request, the requester refers to a [sponsor](sponsor.md) by its [`sponsorAddress`](sponsor.md#sponsorAddress), which means "fulfill my request with the [sponsor wallet](sponsor-wallet.md) of the sponsor identified by `sponsorAddress`". Doing so requires the requester to be [sponsored](sponsor.md) by the said sponsor.
+A requester is a contract that makes Airnode requests. While making a request, the requester refers to a [sponsor](sponsor.md) by its [`sponsorAddress`](sponsor.md#sponsorAddress), which means "fulfill my request with the [sponsor wallet](sponsor-wallet.md) of the sponsor identified by `sponsorAddress`. Doing so requires the requester to be [sponsored](sponsor.md) by the said sponsor.
 
 Note that the requester is the contract that makes the request. The requester may specify the request such that the request is fulfilled by the Airnode calling back another contract.
 

--- a/docs/next/reference/protocols/request-response/sponsor-wallet.md
+++ b/docs/next/reference/protocols/request-response/sponsor-wallet.md
@@ -7,7 +7,7 @@ title: Sponsor Wallet
 <TocHeader />
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
-Each [Airnode](Airnode.md) can keep a sponsor wallet for each [sponsor](requester.md) which is identified by a sponsorAddress/airnodeAddress pair. [Requesters](requester.md) that have been  [sponsored](sponsorship.md) by a sponsor, can specify their requests be fulfilled by the  sponsor wallets belonging to the sponsor. This allows the sponsor to cover the gas cost of request fulfillments by the Airnode.
+Each [Airnode](Airnode.md) can keep a `sponsor-wallet` for each [sponsor](requester.md) which is identified by a `sponsorAddress/airnodeAddress` pair. [Requesters](requester.md) that have been  [sponsored](sponsorship.md) by a sponsor, can specify their requests be fulfilled by the  `sponsor-wallets` belonging to the sponsor. This allows the sponsor to cover the gas cost of request fulfillments by the Airnode.
 
 ## Deriving the address of the sponsor wallet
 

--- a/docs/next/reference/protocols/request-response/sponsor.md
+++ b/docs/next/reference/protocols/request-response/sponsor.md
@@ -4,6 +4,8 @@ title: Sponsor
 
 # {{$frontmatter.title}}
 
+<TitleSpan left=137>Concepts and<br/>Definitions</TitleSpan>
+
 <TocHeader />
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
@@ -11,18 +13,30 @@ A sponsor is an entity (individual, business, etc.) whose contracts make request
 
 After a requester makes a request, the Airnode uses the respective sponsor's [sponsor wallet](sponsor-wallet.md) to fulfill the request, meaning that the sponsor covers the gas cost. This relationship between the sponsor and the requester is announced by the sponsor [sponsoring](sponsorship.md) the requester.
 
-## sponsorAddress
-A sponsor needs to identify itself when sponsoring a requester or deriving a sponsor wallet for an Airnode. This is done with a sponsorAddress which is usually the default BIP derivation path `m/44'/60'/0'/0/0` of a digital wallet owned by the sponsor. The sponsor can use a different address from the wallet if desired such as `m/44'/60'/0'/0/2`.
+## `sponsorAddress`
+A sponsor is identified by a `sponsorAddress` which is usually the default account `m/44'/60'/0'/0/0` of a BIP 44 wallet owned by the sponsor. The sponsor can use a different address from the wallet if desired such as `m/44'/60'/0'/0/2`.
 
-- A sponsor uses their sponsorAddress and the contract address of a requester to sponsor the requester, see [Sponsorship](sponsorship.md).
+Note that a sponsor could use multiple addresses from multiple wallets. Below are some example reasons why one would want to have multiple `sponsorAddress` identities on-chain:
 
-- A sponsor uses their sponsorAddress and the <FixInline>Can use either?</FixInline> airnodeAddress or [`xpub`](airnode.md#xpub) of an Airnode to derive the address of a [sponsor wallet](sponsor-wallet.md) for the Airnode.
+- To keep separate `sponsor-wallets` for two separate use-cases for easier accounting.
+- To duplicate transaction queues for a single use-case and increase response throughput.
 
-When the sponsorAddress used to sponsor the requester, matches an Airnode sponsor wallet that was derived using the same sponsorAddress, the requester can make requests of the Airnode. 
+### PLACE THESE
 
-## Sponsors and Identity
+- A sponsor uses their `sponsorAddress` and the contract address of a requester to sponsor the requester, see [Sponsorship](sponsorship.md).
 
-Note that a sponsor could use multiple sponsorAddresses. Below are some example reasons why one would want to have multiple sponsorAddress identities on-chain:
+- A sponsor uses their `sponsorAddress` and the `airnodeAddress` of a particular Airnode to derive a [sponsor-wallet](sponsor-wallet.md) for the Airnode.
 
-- To keep separate sponsor wallets for two separate use-cases for easier accounting
-- To duplicate transaction queues for a single use-case and increase response throughput
+~~When the `sponsorAddress` used to sponsor the requester, matches an Airnode [`sponsor-wallet`](sponsor.md#sponsor-wallet) that was derived using the same `sponsorAddress`, the requester can make requests of the Airnode.~~
+
+
+## Sponsoring a Requester
+
+Teh 
+
+## `sponsor-wallet`
+
+When a sponsor wishes to access an Airnode (via a requester) it must create a `sponsor-wallet` for the Airnode. Requesters that have been sponsored by a sponsor, can specify their requests be fulfilled by the `sponsor-wallet` belonging to the sponsor. This allows the sponsor to cover the gas cost of request fulfillments by the Airnode.
+
+#
+

--- a/docs/next/reference/protocols/request-response/sponsorship.md
+++ b/docs/next/reference/protocols/request-response/sponsorship.md
@@ -4,10 +4,10 @@ title: Sponsorship
 
 # {{$frontmatter.title}}
 
-A [sponsor](sponsor.md) announcing that a [requester](requester.md) can specify their requests to be fulfilled by the sponsor's [sponsor wallet](sponsor-wallet.md) is called a sponsorship. This is done by the sponsor calling `AirnodeRrp.sol` with the requester's contract address. This verifies that a requester is sponsored by the sponsor, whose sponsor wallet it wants to have the request fulfilled with is done at the protocol level (and not by Airnodes).
+A [sponsor](sponsor.md) announcing that a [requester](requester.md) can specify their requests to be fulfilled by the sponsor's [sponsor wallet](sponsor-wallet.md) is called a sponsorship. This is done by the sponsor calling `AirnodeRrp.sol` with the requester's contract address. This verifies that a requester is sponsored by the sponsor, whose `sponsor-wallet` it wants to have the request fulfilled with is done at the protocol level (and not by Airnodes).
 
 ## How an sponsored requester refers to the sponsor
 
-A requester can have multiple sponsors that have sponsored it. While making a request, the requester provides the `sponsorAddress` that it wants to have the request fulfilled by. The protocol contract checks if the requester is sponsored, and if so, emits the request event.
+1. A requester can have multiple sponsors that have sponsored it. While making a request, the requester provides the `sponsorAddress` that it wants to have the request fulfilled by. The protocol contract checks if the requester is sponsored, and if so, emits the request event.
 
-Airnode derives the sponsor wallet address using the provided `sponsorAddress`, then checks if this matches `sponsorWallet`. Airnode will ignore the request if the two do not match. This is done this way because deriving the sponsor wallet address from the `sponsorAddress` on-chain is not feasible.
+2. Next Airnode derives the `sponsor-wallet` address using the provided `sponsorAddress`, then checks if this matches `sponsorWallet`. Airnode will ignore the request if the two do not match. This is done this way because deriving the sponsor wallet address from the `sponsorAddress` on-chain is not feasible.


### PR DESCRIPTION
The strategy was to clear out airnodeId and introduce airnodeAddress which is the unique identifier of an Airnode across all chains. It comes from the default address of the BIP wallet created by the deployer command deploy which takes mnemonic from the API provider and derives the wallet to get the address.