### PR TITLE
Update Proposals language and misc

### DIFF
--- a/docs/pre-alpha/members/governance/proposals.md
+++ b/docs/pre-alpha/members/governance/proposals.md
@@ -8,10 +8,10 @@ title: Proposals
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
 ## Requirements
-To create a proposal, you must hold at least 0.1% of the total pool shares. This required percentage is set in the Pool contract can be adjusted by the DAO.
+To create a proposal, you must hold at least 0.1% of the total pool shares. This required percentage is set in the Pool contract and may be updated by a DAO proposal as described under [Proposal Types](#proposal-types) below.
 
 ## Proposal Creation
-Proposals can be created from the "Governance" tab of the DAO portal. Connect an account with sufficient voting power and click "New Proposal." Then fill out the form. Note the tooltips and the formatting in this example:
+Proposals can be created from the "Governance" tab of the DAO Dashboard. Connect an account with sufficient voting power and click "New Proposal." Then fill out the form. Note the tooltips and the formatting in this example:
 
 <p align="center">
   <img src="../../figures/new-proposal.png" width="700" />
@@ -22,7 +22,7 @@ Proposals can be submitted to either the *Primary* or *Secondary* voting app. Th
 In general, the Primary voting app has a larger treasury and more permissions but has more stringent voting settings. For a technical breakdown of the different permissions granted to the DAO's two voting apps (and corresponding Agents) see this [README](https://github.com/api3dao/api3-dao/blob/develop/packages/dao/README.md#permissions).
 
 ### Proposal Types
-The following parameters can be updated via DAO proposal, by proposing to call functions in the [pool contract](../README.md):
+The following parameters can be updated via DAO proposal by calling functions in the [pool contract](../contract-architecture/pool.md). For reference, percentage values are based on `10^18 = 100%`.
 
 |Parameter Name |Initial Value (units) |Function Signature |Description |
 |--- |--- |--- |--- |
@@ -30,11 +30,11 @@ The following parameters can be updated via DAO proposal, by proposing to call f
 |aprUpdateStep |1 * 10^16 (%*10^16) |`setAprUpdateStep(uint256 _aprUpdateStep)` |Percentage reward APR will be increased or decreased by |
 |maxApr |75 * 10^16 (%*10^16) |`setMaxApr(uint256 _maxApr)` |Maximum reward APR |
 |minApr |2.5 * 10^16 (%*10^16) |`setMinApr(uint256 _minApr)` |Minimum reward APR |
-|proposalVotingPowerThreshold |1 * 10^17 (%*10^16) |`setProposalVotingPowerThreshold(uint256 _proposalVotingPowerThreshold)` |Percentage of all shares that must be held to create a new proposal |
+|proposalVotingPowerThreshold |0.1 * 10^16 (%*10^16) |`setProposalVotingPowerThreshold(uint256 _proposalVotingPowerThreshold)` |Percentage of all shares that must be held to create a new proposal |
 |unstakeWaitPeriod |604800 (seconds) |`setUnstakeWaitPeriod(uint256 _unstakeWaitPeriod)` |Length of time a member must wait after scheduling unstake before unstaking tokens from the pool |
 
 ## Proposal Execution
-If a proposal is [ready for execution](../contract-architecture/voting.md#key-functions), the execute button will appear on its details page:
+Once a proposal is [ready for execution](../contract-architecture/voting.md#key-functions), anyone can execute it using the Execute button that appears on its details page:
 
 <p align="center">
   <img src="../../figures/executable-proposal.png" width="700" />
@@ -42,6 +42,6 @@ If a proposal is [ready for execution](../contract-architecture/voting.md#key-fu
 
 ## Using ENS Names
 
-You can use the [ENS app](https://app.ens.domains/) to register a name and associate it with an Ethereum account. Then, while entering your proposal parameters, you can use this ENS name instead of the account address. Before making the transaction that will create the proposal, the DAO dashboard will look up the address that the ENS name is pointing to, and use the raw address in the proposal. Therefore, changing the address that the ENS name is pointing to after this look up operation **WILL NOT** have an affect on the proposal.
+You are encouraged to use the [ENS app](https://app.ens.domains/) to register a name and associate it with an Ethereum account. Then, while entering your proposal parameters, you can use this ENS name instead of the account address. Before making the transaction that will create the proposal, the DAO dashboard will look up the address that the ENS name is pointing to, and use the raw address in the proposal. Therefore, changing the address that the ENS name is pointing to after this look up operation **WILL NOT** have an affect on the proposal.
 
-If you also want the voters to see the ENS name instead of the raw address to make your proposal more readable, you will have to use the [ENS app](https://app.ens.domains/) to set a reverse record pointing to your ENS name (i.e., you need to have your raw address point to the ENS name). For example, if you are making a proposal to make a `transfer(address,amount)` call to an ERC20 token contract where `address` will be the address of a multisig wallet, you can [set a reverse record with the multisig](https://medium.com/the-ethereum-name-service/you-can-now-manage-ens-names-with-gnosis-safe-9ddcb7e6c4ac) to your ENS name for it to appear on the proposal details page. See Parameters in [this proposal](https://api3.eth.link/#/history/secondary-6) for an example.
+For voters to see your ENS name instead of the raw address on the proposal details page, you will have to use the [ENS app](https://app.ens.domains/) to set a reverse record pointing to your ENS name (i.e., you need to have your raw address point to the ENS name). If your proposal will make a `transfer(address,amount)` call to an ERC20 token contract where `address` is the address of a _multisig_ wallet, you can [set a reverse record with the multisig](https://medium.com/the-ethereum-name-service/you-can-now-manage-ens-names-with-gnosis-safe-9ddcb7e6c4ac) to your ENS name. See Parameters in [this proposal](https://api3.eth.link/#/history/secondary-6) for an example.


### PR DESCRIPTION
The PR updates the following on the Proposals page:

- Typo: `proposalVotingPowerThreshold` was erroneously `1 * 10^17` which equals 10%. I've updated it to `0.1 * 10^16` so it is consistent with the other 10^16 values (although it could also be 1*10^15)
- Stated explicitly `10^18 = 100%`
- Internal & external links
- Grammar
- Consistent use of "DAO Dashboard"
- Rephrased sentences within the ENS section to encourage use and more clearly illustrate setup for raw address vs. multisig 