### PR TITLE
Run markdown link check on PRs

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,5 +1,7 @@
 name: Check Markdown links
-on: push
+on:
+  push:
+  pull_request:
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I added `pull_request` as a trigger after noticing the Action wasn't running on PRs until after merge. The link check could get more sophisticated by checking only changed files on push / PR while still checking all links regularly e.g. daily by running a separate [schedule](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events) Action, but I think this is overkill at the moment.