### PR TITLE
Add DAO Tracker page sourced from root dir

### DIFF
--- a/docs/enormous/dao-tracker.md
+++ b/docs/enormous/dao-tracker.md
@@ -1,0 +1,21 @@
+---
+title: DAO Tracker
+---
+
+# {{$frontmatter.title}}
+
+<TOC class="table-of-contents" :include-level="[2,3]" />
+
+The [DAO Tracker](https://enormous.cloud/dao/api3/tracker/) is a community-developed tool that provides additional insight into the DAO beyond what is offered by the intentionally minimalist DAO Dashboard. Its [open source codebase](https://github.com/EnormousCloud/api3-dao-tracker) was developed by GitHub user [EnormousCloud](https://github.com/EnormousCloud).
+
+The DAO Tracker features the following pages and content:
+
+1. **Overview** - APR and staking data for current and previous epochs as well as a breakdown of API3 token supply by status, for example number tokens locked by governance. The overview page also contains a list of API3 smart contracts and the circulating supply of API3.
+
+2. **Rewards** - history of staking rewards containing the APR, number of members that were staking, API3 staked, and rewards minted of each epoch.
+
+3. **Wallets** - staking participant wallets along with the voting power (absolute and percent), ownership, and accrued rewards of each. If the wallet has an associated ENS name, that is also shown with the wallet address.
+
+4. **Votings** - pending, executed, and rejected proposals along with the percentage votes for and against each.
+
+5. **Treasury** - contract addresses and balances of each API3 DAO treasury.

--- a/docs/next/grp-members/dao-tracker.md
+++ b/docs/next/grp-members/dao-tracker.md
@@ -1,0 +1,1 @@
+../../enormous/dao-tracker.md

--- a/docs/next/sidebar.js
+++ b/docs/next/sidebar.js
@@ -111,6 +111,7 @@ module.exports = [
             'grp-members/dashboard/videos'
         ]
       },
+      {title: 'DAO Tracker', path: 'grp-members/dao-tracker'},
     ]
   },
   {title:'_________________',collapsable: false},

--- a/docs/pre-alpha/members/dao-tracker.md
+++ b/docs/pre-alpha/members/dao-tracker.md
@@ -1,0 +1,1 @@
+../../enormous/dao-tracker.md

--- a/docs/pre-alpha/sidebar.js
+++ b/docs/pre-alpha/sidebar.js
@@ -28,6 +28,7 @@ module.exports = [
       {title:'Overview', path:'members/'},
       {title:'DAO Dashboard', path:'https://api3.eth.link/'},
       'members/videos',
+      {title: 'DAO Tracker', path: 'members/dao-tracker'},
       {
         title:'Contract Architecture',
         children: [


### PR DESCRIPTION
Features a single `/enormous/dao-tracker.md`  page at the `/docs` root referenced by symlink from the pre-alpha and the next folders. Tested by pushing to gh-pages fork.