### PR TITLE
Update markdown-link-check and fix links

### DIFF
--- a/.github/workflows/markdown-link-check.config.json
+++ b/.github/workflows/markdown-link-check.config.json
@@ -6,7 +6,7 @@
     },
     {
       "pattern": "^/",
-      "replacement": "https://github.com/api3dao/api3-docs/tree/stage/"
+      "replacement": "https://github.com/api3dao/api3-docs/tree/stage/docs/"
     }
   ],
   "retryOn429": true,

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -12,4 +12,4 @@ jobs:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'no'
         config-file: .github/workflows/markdown-link-check.config.json
-        folder-path: 'docs/dev, docs/airnode/pre-alpha, docs/dao-members'
+        folder-path: 'docs/dev, docs/airnode/pre-alpha, docs/dao-members, docs/common'

--- a/docs/airnode/pre-alpha/_deprecated/members/dao-tracker.md
+++ b/docs/airnode/pre-alpha/_deprecated/members/dao-tracker.md
@@ -1,1 +1,1 @@
-../../common/enormous/dao-tracker.md
+../../../../common/enormous/dao-tracker.md

--- a/docs/airnode/pre-alpha/tutorials/airnode-starter.md
+++ b/docs/airnode/pre-alpha/tutorials/airnode-starter.md
@@ -92,8 +92,8 @@ _Following these instructions to deploy an Airnode on AWS is [free](https://aws.
 
 
 Normally, you would need to do two things before you deploy an Airnode:
-1. [Specify the API integration](https://api3dao.github.io/api3-docs/pre-alpha/guides/provider/api-integration.html)
-1. [Configure your Airnode](https://api3dao.github.io/api3-docs/pre-alpha/guides/provider/configuring-airnode.html)
+1. [Specify the API integration](../guides/provider/api-integration.md)
+1. [Configure your Airnode](../guides/provider/configuring-airnode.md)
 
 <!-- markdown-link-check-disable -->
 <!-- The CoinGecko API docs have been returning a 503 but they are there. -->

--- a/docs/dev/common-directory.md
+++ b/docs/dev/common-directory.md
@@ -18,7 +18,7 @@ ln -s ../../enormous/dao-tracker.md dao-tracker.md
 <Fix>Needs write-up.</Fix>
 
 This will not work as a **markdown link**, the sidebar goes away.<br/>
-[Go to contribute](introduction/contributing.md)
+[Go to contribute](../common/introduction/contributing.md)
 
 Goes directly to Airnode `/next`, **markdown link** with full path.<br/>
 [Go to contribute in /next](/airnode/next/introduction/contributing.md)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "copy:navbar": "cp docs/.vuepress/components/Navbar.vue node_modules/@vuepress/theme-default/components/Navbar.vue",
     "copy:sidebar": "cp docs/.vuepress/components/Sidebar.vue node_modules/@vuepress/theme-default/components/Sidebar.vue",
     "copy:searchbox": "cp docs/.vuepress/components/SearchBox.vue node_modules/@vuepress/plugin-search/Searchbox.vue",
-    "test:links:prod": "for file in $(find ./docs/dao-members ./docs/airnode/pre-alpha -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
+    "test:links:prod": "for file in $(find ./docs/dao-members ./docs/airnode/pre-alpha ./docs/common -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
     "test:links:next": "for file in $(find ./docs/airnode/next -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
+    "test:links:dev": "for file in $(find ./docs/dev -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
     "docs:dev": "yarn copy:navbar; yarn copy:sidebar; yarn copy:searchbox; vuepress dev docs",
     "docs:build": "yarn copy:navbar; yarn copy:sidebar; yarn copy:searchbox; vuepress build docs"
   },


### PR DESCRIPTION
markdown-link-check passes (which excludes `/docs/airnode/next`)

Fix broken symlink
Fix airnode-starter & common links
Add docs/common to markdown-link-check Action
Add docs/common to local `yarn test:links:prod`
Add new `yarn test:links:dev` command
Update markdown-link-check config to handle root links correctly