### PR TITLE
Add docs to contributing

### DIFF
--- a/docs/common/introduction/contributing.md
+++ b/docs/common/introduction/contributing.md
@@ -8,7 +8,9 @@ title: Contributing
 
 (To the API3 DAO as a technical member)
 
-This is aimed to guide an API3 DAO member with a technical background to contribute to the project (through development, integrations, writing documentation, etc.)
+## Prerequisites
+
+This is aimed to guide an API3 DAO member with a technical background to contribute to the project (through development, integrations, writing documentation, etc.).
 The general point is that one needs to be able to use a solution proficiently before being able to improve it.
 Therefore, you are recommended to do all of the below before attempting to contribute, and make sure to ask any questions you have on [our Discord](https://discord.gg/qnRrcfnm5W).
 
@@ -17,19 +19,19 @@ It is a light read that touches on all subjects that you will need to know about
 
 - To get a general grasp of the project, read the [API3 whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf) and our <CommonLink :path="'blog-posts.md'">blog posts</CommonLink> on Medium.
 
-- Read the entirety of the [API3 docs](https://github.com/api3dao/api3-docs).
+- Read the entirety of these docs.
 Take notes and cross-reference, but do not expect to understand everything.
 Feel free to ask questions.
 
-- Run and understand the example projects:
-
-  https://github.com/api3dao/airnode-client-examples/tree/pre-alpha
-
-  https://github.com/api3dao/airnode-starter/tree/pre-alpha
+- Run and understand the Airnode starter tutorial
 
 - (Optional, but ideal) Integrate an API to an Airnode without using any guide, deploy the Airnode, and build a dApp that uses the Airnode.
 Better yet, join one of our hackathons.
 
-- (For the curious) Explore all the repos hosted on our Github, go through the issues, PRs, etc.
+- (For the curious) Explore all the repos hosted on [our Github](https://github.com/api3dao/), go through the issues, PRs, etc.
 
 This guide will be updated as we produce more material, and feel free to create [issues](https://github.com/api3dao/api3-docs/issues) to make suggestions.
+
+## Contributing to the docs
+
+See the [dev documentation](/dev/) for an overview of the API3 docs site and for instructions on how to run the project locally.


### PR DESCRIPTION
Also remove explicit reference to soon-outdated pre-alpha `airnode-client-examples` (See AN-189)