### PR TITLE
Add specification conversion tip

### DIFF
--- a/docs/airnode/next/grp-providers/guides/build-an-airnode/api-integration.md
+++ b/docs/airnode/next/grp-providers/guides/build-an-airnode/api-integration.md
@@ -17,7 +17,11 @@ A successful integration of an API with an Airnode requires the mapping of each 
 
 OIS is a mapping of API operations, such as  `GET /token/{id}`, to Airnode endpoints. When a requester contract calls an AirnodeRRP contract request function, such as `makeRequest(..., callData)`, the callData is communicated to the off-chain Airnode which uses OIS mappings to translate the callData into a valid HTTP request for the appropriate API operation.
 
-Therefore, only thing needed to integrate an API to Airnode is to create an OIS json object which lives in an Airnode's config.json file. This guide is an instructive approach to creating an OIS. As a point of reference, refer to [Oracle Integration Specifications (OIS)](../../../reference/specifications/ois.md) in the Technology section of these docs for additional input and understanding. It may be useful, but not necessary, to reference the [OAS 3.0.3 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) about fields related to API specifications.
+Therefore, only thing needed to integrate an API to Airnode is to create an OIS json object which lives in an Airnode's config.json file. This guide is an instructive approach to creating an OIS. As a point of reference, refer to [Oracle Integration Specifications (OIS)](../../../reference/specifications/ois.md) in the Technology section of these docs for additional input and understanding. It may be useful, but not necessary, to reference the [OpenAPI Specification (OAS) 3.0.3 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) about fields related to API specifications.
+
+::: tip Specification Conversion
+To assist in converting between various specifications e.g. from OAS to OIS, there is a `convert` command within the Airnode [validator](https://github.com/api3dao/airnode/tree/master/packages/validator#airnodeconvertor) package.
+:::
 
 <!-- markdownlint-disable -->
 <details class="collapse-box">
@@ -25,8 +29,6 @@ Therefore, only thing needed to integrate an API to Airnode is to create an OIS 
   Other tips while this guide.
   </summary>
   
-  - Refer to the [Oracle Integration Specifications (OIS)](../../../reference/specifications/ois.md) reference while using this guide.
-
   - Open the [OIS template](../../../reference/templates/ois-json.md) in another browser window to follow along.
 
   - View an example of an [Airnode config.json file](../../tutorial/config-json.md) from the Airnode Starter tutorial.
@@ -396,7 +398,5 @@ This was all!
 We specified the API operations and Airnode endpoints. Each Airnode endpoint maps to an API operation, and each Airnode endpoint parameter or fixedOperationParameter maps to an API operation parameter. The resulting OIS includes no user-specific information, which means that you can share it for others to easily provide the same services (for example, to set up a third-party oracle network).
 
 Note that there was some subjectivity while defining the Airnode endpoints. This means that two different OISes can exist for the same exact API, differing based on how the integrators designed the interface that the requester will use. However, in most cases, one would simply map API operations to Airnode endpoints directly, and let the requester provide all API operation parameters through the Airnode endpoint parameters.
-
-Currently there is no tool that generates an `endpoints` list that maps to `apiSpecifications.paths` one-to-one. If you would like to help build this, please join the conversation in [this issue](https://github.com/api3dao/airnode/issues/153).
 
 Now that we have our OIS object, the next step is [Configuring Airnode](configuring-airnode.md).

--- a/docs/airnode/pre-alpha/guides/provider/api-integration.md
+++ b/docs/airnode/pre-alpha/guides/provider/api-integration.md
@@ -18,9 +18,11 @@ To integrate a System X to a System Y, we need to do three things:
 - Oracle endpoints are mapped to API operations
 
 Therefore, the only thing you need to do to integrate an API to Airnode is to create an OIS.
-You can do this simply by reading the [OIS docs](../../airnode/specifications/ois.md) and creating the OIS for your specific API and use-case.
-This guide aims to follow a more instructive approach and give some tips along the way.
-Make sure to refer to the [OIS docs](../../airnode/specifications/ois.md) when you need further details, and you can also refer to the [OAS 3.0.3 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) about fields related to API specifications.
+This guide is an instructive approach to creating an OIS. As a point of reference, refer to the [OIS docs](../../airnode/specifications/ois.md) when you need further details. It may be useful, but not necessary, to reference the [OpenAPI Specification (OAS) 3.0.3 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) about fields related to API specifications.
+
+::: tip Specification Conversion
+To assist in converting between various specifications e.g. from OAS to OIS, there is a `convert` command within the Airnode [validator](https://github.com/api3dao/airnode/tree/master/packages/validator#airnodeconvertor) package.
+:::
 
 ## OIS Template
 
@@ -217,5 +219,3 @@ The resulting OIS includes no user-specific information, which means that you ca
 Note that there was some subjectivity while defining the endpoints.
 This means that two different OISes can exist for the same exact API, differing based on how the integrators designed the interface that the requester will use.
 However, in most cases, one would simply map API operations to endpoints directly, and let the requester provide all API operation parameters through the endpoint parameters.
-At the moment, we do not have a tool that generates an `endpoints` list that maps to `apiSpecifications.paths` one-to-one.
-If you would like to help build this, please join the conversation in [this issue](https://github.com/api3dao/airnode/issues/153).


### PR DESCRIPTION
Adds a tip box to pre-alpha and next referencing the `convert` command of the validator package to help with OIS generation. 

The text:
> Currently there is no tool that generates an `endpoints` list that maps to `apiSpecifications.paths` one-to-one. If you would like to help build this, please join the conversation in [this issue](https://github.com/api3dao/airnode/issues/153).

became obsolete when api3dao/airnode#195 closed api3dao/airnode#153