### PR TITLE
Wrap deployer command sample path with quotes

### DIFF
--- a/docs/airnode/next/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/next/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -95,7 +95,7 @@ Then, in this same directory, run the following command.
   docker run -it --rm \
     --env-file .env \
     --env COMMAND=deploy-first-time \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:0.1.0
   ```
 :::
@@ -104,7 +104,7 @@ Then, in this same directory, run the following command.
   docker run -it --rm ^
     --env-file .env ^
     --env COMMAND=deploy-first-time ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:0.1.0
   ```
 :::

--- a/docs/airnode/next/grp-providers/using-docker.md
+++ b/docs/airnode/next/grp-providers/using-docker.md
@@ -53,7 +53,7 @@ Note that `nodeSettings.cloudProvider` should be `local`.
       ```sh
       docker run -it --rm \
           --env-file .env \
-          -v $(pwd):/airnode/out \
+          -v "$(pwd):/airnode/out" \
           api3/airnode-client:pre-alpha
       ```
     :::
@@ -61,7 +61,7 @@ Note that `nodeSettings.cloudProvider` should be `local`.
       ```sh
       docker run -it --rm ^
           --env-file .env ^
-          -v "%cd%":/airnode/out ^
+          -v "%cd%:/airnode/out" ^
           api3/airnode-client:pre-alpha
       ```
     :::
@@ -90,7 +90,7 @@ docker build . -t api3/airnode-deployer:latest
   docker run -it --rm \
     --env-file aws.env \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
-    -v $(pwd)/output:/app/output \
+    -v "$(pwd)/output:/app/output" \
     api3/deployer:latest deploy
   ```
 :::
@@ -99,7 +99,7 @@ docker build . -t api3/airnode-deployer:latest
   docker run -it --rm ^
     --env-file .env ^
     --env COMMAND=deploy-first-time ^
-    -v "%cd%"/output:/app/output ^
+    -v "%cd%/output:/app/output" ^
     api3/deployer:latest deploy
   ```
 :::
@@ -113,7 +113,7 @@ docker build . -t api3/airnode-deployer:latest
   docker run -it --rm \
     --env-file aws.env \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
-    -v $(pwd)/output:/app/output \
+    -v "$(pwd)/output:/app/output" \
     api3/deployer:latest remove -r output/receipt.json
   ```
 :::
@@ -122,7 +122,7 @@ docker build . -t api3/airnode-deployer:latest
   docker run -it --rm ^
     --env-file aws.env ^
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) ^
-    -v "%cd%"/output:/app/output ^
+    -v "%cd%/output:/app/output" ^
     api3/deployer:latest remove -r output/receipt.json
   ```
 :::

--- a/docs/airnode/pre-alpha/guides/docker/client-image.md
+++ b/docs/airnode/pre-alpha/guides/docker/client-image.md
@@ -39,7 +39,7 @@ title: Client image instructions
       ```sh
       docker run -it --rm \
           --env-file .env \
-          -v $(pwd):/airnode/out \
+          -v "$(pwd):/airnode/out" \
           api3/airnode-client:pre-alpha
       ```
     :::
@@ -47,7 +47,7 @@ title: Client image instructions
       ```sh
       docker run -it --rm ^
           --env-file .env ^
-          -v "%cd%":/airnode/out ^
+          -v "%cd%:/airnode/out" ^
           api3/airnode-client:pre-alpha
       ```
     :::

--- a/docs/airnode/pre-alpha/guides/docker/deployer-image.md
+++ b/docs/airnode/pre-alpha/guides/docker/deployer-image.md
@@ -27,7 +27,7 @@ title: Deployer image instructions
   docker run -it --rm \
     --env-file .env \
     --env COMMAND=deploy-first-time \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -36,7 +36,7 @@ title: Deployer image instructions
   docker run -it --rm ^
     --env-file .env ^
     --env COMMAND=deploy-first-time ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -50,7 +50,7 @@ title: Deployer image instructions
   docker run -it --rm \
     --env-file .env \
     --env COMMAND=redeploy \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -59,7 +59,7 @@ title: Deployer image instructions
   docker run -it --rm ^
     --env-file .env ^
     --env COMMAND=redeploy ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -77,7 +77,7 @@ Note that you must replace `$MNEMONIC` and `$REGION` with your values Enclose yo
     --env COMMAND=deploy-mnemonic \
     --env MNEMONIC=$MNEMONIC \
     --env REGION=$REGION \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -88,7 +88,7 @@ Note that you must replace `$MNEMONIC` and `$REGION` with your values Enclose yo
     --env COMMAND=deploy-mnemonic ^
     --env MNEMONIC=$MNEMONIC ^
     --env REGION=$REGION ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -105,7 +105,7 @@ Note that you must replace `$RECEIPT_FILENAME` with your value and `$RECEIPT_FIL
     --env-file .env \
     --env COMMAND=remove-with-receipt \
     --env RECEIPT_FILENAME=$RECEIPT_FILENAME \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -115,7 +115,7 @@ Note that you must replace `$RECEIPT_FILENAME` with your value and `$RECEIPT_FIL
     --env-file .env ^
     --env COMMAND=remove-with-receipt ^
     --env RECEIPT_FILENAME=$RECEIPT_FILENAME ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -133,7 +133,7 @@ Note that you must replace `$PROVIDER_ID_SHORT` and `$REGION` with your values.
     --env COMMAND=remove-mnemonic \
     --env PROVIDER_ID_SHORT=$PROVIDER_ID_SHORT \
     --env REGION=$REGION \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -144,7 +144,7 @@ Note that you must replace `$PROVIDER_ID_SHORT` and `$REGION` with your values.
     --env COMMAND=remove-mnemonic ^
     --env PROVIDER_ID_SHORT=$PROVIDER_ID_SHORT ^
     --env REGION=$REGION ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -163,7 +163,7 @@ Note that you must replace `$PROVIDER_ID_SHORT`, `$REGION` and `$STAGE` with you
     --env PROVIDER_ID_SHORT=$PROVIDER_ID_SHORT \
     --env REGION=$REGION \
     --env STAGE=$STAGE \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -175,7 +175,7 @@ Note that you must replace `$PROVIDER_ID_SHORT`, `$REGION` and `$STAGE` with you
     --env PROVIDER_ID_SHORT=$PROVIDER_ID_SHORT ^
     --env REGION=$REGION ^
     --env STAGE=$STAGE ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::

--- a/docs/airnode/pre-alpha/guides/provider/deploying-airnode.md
+++ b/docs/airnode/pre-alpha/guides/provider/deploying-airnode.md
@@ -45,7 +45,7 @@ Then, in this same directory, run the following command.
   docker run -it --rm \
     --env-file .env \
     --env COMMAND=deploy-first-time \
-    -v $(pwd):/airnode/out \
+    -v "$(pwd):/airnode/out" \
     api3/airnode-deployer:pre-alpha
   ```
 :::
@@ -54,7 +54,7 @@ Then, in this same directory, run the following command.
   docker run -it --rm ^
     --env-file .env ^
     --env COMMAND=deploy-first-time ^
-    -v "%cd%":/airnode/out ^
+    -v "%cd%:/airnode/out" ^
     api3/airnode-deployer:pre-alpha
   ```
 :::


### PR DESCRIPTION
Spaces have been showing up in use cases where spaces are in paths and username  paths for command line calls to the docker images/clients.

```sh
docker run -it --rm \
  --env-file .env \
  --env COMMAND=deploy-first-time \
  -v "$(pwd):/airnode/out" \    <-- double quotes added here
  api3/airnode-deployer:0.1.0
  ```