### PR TITLE
Mention that HTTP gateway is only available on serverless

### DIFF
--- a/docs/airnode/next/grp-providers/guides/build-an-airnode/http-gateway.md
+++ b/docs/airnode/next/grp-providers/guides/build-an-airnode/http-gateway.md
@@ -7,6 +7,8 @@ title: HTTP Gateway
 <TocHeader />
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
+> HTTP Gateway feature which is only available when deploying to serverless
+
 As part of the Airnode deployment you can decide to deploy an HTTP Gateway. The gateway allows the testing of defined endpoints without accessing the blockchain. You provide endpoint arguments to get a response from an integrated API. Gateway calls the API simulating Airnode. This results in confirmation your integration is set up properly.
 
 :::warning HTTP Gateway (optional)


### PR DESCRIPTION
I think we should mention features which are only available on a particular "airnode type" explicitely.

But you can close this if you disagree.