### PR TITLE
Changes for docker and deployment

### DIFF
--- a/docs/airnode/next/grp-providers/docker/README.md
+++ b/docs/airnode/next/grp-providers/docker/README.md
@@ -1,0 +1,27 @@
+---
+title: Overview
+---
+
+# {{$frontmatter.title}}
+
+<TocHeader />
+<TOC class="table-of-contents" :include-level="[2,3]" />
+
+Using Docker is the easiest way to both deploy an Airnode and to run an Airnode locally. There are two docker images for each: the deployer image and the client image. 
+
+- The [deployer image](./deployer-image.md) deploys the node in the form of serverless functions to a cloud provider (e.g. AWS Lambda). 
+
+- The [client image](client-image.md) is the node itself, containerized. The container can be run locally or deployed to the cloud (e.g. AWS EC2 or Lightsail). 
+
+## Development Use Cases
+
+1. You can run the client image container locally while developing, and use the deployer image to deploy the serverless functions for production.
+
+2. Run an Airnode that responds to two chains using the deployer image.
+ 
+   - One is development using a chain provider url that is pointed pointed to a testnet.
+   - Another is production using a chain provider url that is pointed pointed to mainnet. 
+   
+## Cloud Provider Credentials
+
+In order to deploy Airnode to a cloud provider like AWS, you need to provide your cloud credentials to the container. Airnode currently only supports deploying to AWS.

--- a/docs/airnode/next/grp-providers/docker/client-image.md
+++ b/docs/airnode/next/grp-providers/docker/client-image.md
@@ -1,5 +1,5 @@
 ---
-title: Using Docker
+title: Client Image
 ---
 
 # {{$frontmatter.title}}
@@ -11,10 +11,10 @@ title: Using Docker
 
 Using Docker is the easiest way to both deploy an Airnode and to run an Airnode locally. There are two docker images for each: the deployer image and the client image. 
 
+- The **client image** is the node itself, containerized. The container can be run locally or deployed to the cloud (e.g. AWS EC2 or Lightsail).
 - The **deployer image** deploys the node in the form of serverless functions (e.g. AWS Lambda). 
-- The **client image** is the node itself, containerized. The container can be run locally or deployed to the cloud (e.g. AWS EC2 or Lightsail). 
-
-You would probably run the client image container locally while developing, and use the deployer image to deploy the serverless functions for production.
+ 
+You can run the client image container locally while developing, and use the deployer image to deploy the serverless functions for production. 
 
 ## Client Image
 
@@ -70,6 +70,8 @@ Note that `nodeSettings.cloudProvider` should be `local`.
 
 ## Deployer Image
 
+Use the Docker image to deploy or remove an Airnode from a cloud provider such as AWS. The simplest way is to use the pre-built packages. If you would rather build the images yourself see [11]() and [22]();
+
 1. Build the Docker image
 ```sh
 docker build . -t api3/airnode-deployer:latest
@@ -84,23 +86,31 @@ docker build . -t api3/airnode-deployer:latest
 
 ### `deploy`
 
+Three files are needed to do a deployment to a cloud provider (AWS).
+
+- config.json
+- secrets.env
+- asw.env
+
 :::: tabs
 ::: tab Linux/Mac
   ```sh
   docker run -it --rm \
-    --env-file aws.env \
+  --env-file aws.env \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+    -v "$(pwd)/config:/app/config" \
     -v "$(pwd)/output:/app/output" \
-    api3/deployer:latest deploy
+    @api3/deployer:latest deploy
   ```
 :::
 ::: tab Windows
   ```sh
   docker run -it --rm ^
-    --env-file .env ^
-    --env COMMAND=deploy-first-time ^
-    -v "%cd%/output:/app/output" ^
-    api3/deployer:latest deploy
+    --env-file aws.env ^
+    -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) ^
+    -v "$(pwd)/config:/app/config" ^
+    -v "$(pwd)/output:/app/output" ^
+    @api3/deployer:latest deploy
   ```
 :::
 ::::

--- a/docs/airnode/next/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/next/grp-providers/docker/deployer-image.md
@@ -1,0 +1,72 @@
+---
+title: Deployer Image
+---
+
+# {{$frontmatter.title}}
+
+<TocHeader />
+<TOC class="table-of-contents" :include-level="[2,3]" />
+
+Use the deployer image to deploy or remove an Airnode with a cloud provider such as AWS. The simplest way is to use the pre-built packages. If you would rather build the images yourself see [docker README](https://github.com/api3dao/airnode/tree/master/packages/deployer/docker) in the deploy package.
+
+The deployer image has two commands.
+
+- `deploy`: Deploys or updates an Airnode.
+- `remove`: Removes
+
+See the [Quick Start Demo]() to quickly deploy a pre-configured Airnode using the deployer image.
+
+## `deploy`
+
+The `deploy` command will create the Airnode with a cloud provider or update it if it already exists. Three files are needed to run the deploy command.
+
+- config.json
+- secrets.env
+- aws.env
+
+:::: tabs
+::: tab Linux/Mac
+  ```sh
+  docker run -it --rm \
+  --env-file aws.env \
+    -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+    -v "$(pwd)/config:/app/config" \
+    -v "$(pwd)/output:/app/output" \
+    @api3/deployer:latest deploy
+  ```
+:::
+::: tab Windows
+If you are using Windows, use CMD (and not PowerShell).
+  ```sh
+  docker run -it --rm ^
+    --env-file aws.env ^
+    -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) ^
+    -v "%cd%/config:/app/config" ^
+    -v "%cd%/output:/app/output" ^
+    @api3/deployer:latest deploy
+  ```
+:::
+::::
+
+### `remove`
+
+:::: tabs
+::: tab Linux/Mac
+  ```sh
+  docker run -it --rm \
+    --env-file aws.env \
+    -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+    -v "$(pwd)/output:/app/output" \
+    api3/deployer:latest remove -r output/receipt.json
+  ```
+:::
+::: tab Windows
+If you are using Windows, use CMD (and not PowerShell).
+  ```sh
+  docker run -it --rm ^
+    --env-file aws.env ^
+    -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) ^
+    -v "%cd%/output:/app/output" ^
+    api3/deployer:latest remove -r output/receipt.json
+  ```
+:::

--- a/docs/airnode/next/grp-providers/tutorial/quick-demo/README.md
+++ b/docs/airnode/next/grp-providers/tutorial/quick-demo/README.md
@@ -1,0 +1,46 @@
+---
+title: Quick Deploy
+---
+
+<TitleSpan>Quick Deploy Demo</TitleSpan>
+
+# {{$frontmatter.title}}
+<TocHeader />
+<TOC class="table-of-contents" :include-level="[2,3]" />
+
+This demo is a simple Airnode deployment, using a hands-on approach, to better understand the overall deployment process.
+
+An Airnode deployment uses a Docker image (called [deployer image](../../docker/deployer-image.md)) which in turn requires three files as input.
+
+- [config.json](./config.json.md)
+- [secrets.env](./secrets.env.md)
+- [aws.env](./aws.env.md)
+
+For the purpose of this demo these files have been created for you and only require a few minor changes on your part to make the deployment of the demo Airnode successful. These change are needed for you to supply AWS credentials and a chain provider url.
+
+## Getting Started
+
+Create a folder called `/quick-deploy-demo` with two more internal folders named `/config` and `/output`. Place the contents of the files provided ([config.json](./config.json.md), [secrets.env](./secrets.env.md) and [aws.env](./aws.env.md)) into each.
+
+```
+quick-deploy-demo
+├── aws.env
+├── config
+│   ├── config.json
+│   └── secrets.env
+└── output
+    ├── receipt.json
+```
+
+By default, the deployer image looks for `config.json` and `secrets.env` in `/config`, `aws.env` in `/quick-deploy-demo` and writes `receipt.json` to the `/output` folder. You can place the `aws.env` file into the `/config` folder as well but will need to update its path in the deployer image call.
+
+## Files Changes
+
+
+### config.json
+
+This file requires no changes on your part. It has been created with just one API endpoint.
+
+### secrets.env
+
+### aws.env

--- a/docs/airnode/next/grp-providers/tutorial/quick-demo/aws.env.md
+++ b/docs/airnode/next/grp-providers/tutorial/quick-demo/aws.env.md
@@ -1,0 +1,7 @@
+---
+title: aws.env
+---
+
+<TitleSpan>Quick Deploy Demo</TitleSpan>
+
+# {{$frontmatter.title}}

--- a/docs/airnode/next/grp-providers/tutorial/quick-demo/config.json.md
+++ b/docs/airnode/next/grp-providers/tutorial/quick-demo/config.json.md
@@ -1,0 +1,15 @@
+---
+title: config.json
+---
+
+<TitleSpan>Quick Deploy Demo</TitleSpan>
+
+# {{$frontmatter.title}}
+
+
+{
+  "key":"value"
+
+
+
+}

--- a/docs/airnode/next/grp-providers/tutorial/quick-demo/secrets.env.md
+++ b/docs/airnode/next/grp-providers/tutorial/quick-demo/secrets.env.md
@@ -1,0 +1,7 @@
+---
+title: secrets.env
+---
+
+<TitleSpan>Quick Deploy Demo</TitleSpan>
+
+# {{$frontmatter.title}}

--- a/docs/airnode/next/sidebar.js
+++ b/docs/airnode/next/sidebar.js
@@ -29,10 +29,26 @@ module.exports = [
           'grp-providers/guides/build-an-airnode/deploying-airnode',
         ]
       },
-      'grp-providers/using-docker',
       {
-        title: 'Tutorial', collapsable: true,
+        title: 'Docker Images', collapsable: true, 
+        children:[
+          'grp-providers/docker/',
+          'grp-providers/docker/deployer-image',
+          'grp-providers/docker/client-image',
+        ]
+      },
+      {
+        title: 'Tutorials', collapsable: true,
+        
         children: [
+          {title: 'Quick Deploy Demo',
+            children:[
+              'grp-providers/tutorial/quick-demo/',
+              'grp-providers/tutorial/quick-demo/config.json',
+              'grp-providers/tutorial/quick-demo/secrets.env',
+              'grp-providers/tutorial/quick-demo/aws.env',
+            ]
+          },
           'grp-providers/tutorial/airnode-starter',
           'grp-providers/tutorial/config-json',
           'grp-providers/tutorial/secrets-env',


### PR DESCRIPTION
The details of each file changed is not major at this point. The commit is more of a outline of how to integrate docker and deployers docs in a useful context. The will be more daily updates to come. airnode-starter has yet to be added and as of today was slated to be nothing more than a link back to the monorepo packages/examples.