### PR TITLE
Add prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+/node_modules
+/archived
+/docs/airnode/pre-alpha

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 120,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown",
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:links:next": "for file in $(find ./docs/airnode/next -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
     "test:links:dev": "for file in $(find ./docs/dev -path ./node_modules -prune -false -o -name \"*.md\"); do markdown-link-check --verbose --config .github/workflows/markdown-link-check.config.json \"$file\" || exit 1; done;",
     "docs:dev": "yarn copy:navbar; yarn copy:sidebar; yarn copy:searchbox; vuepress dev docs",
-    "docs:build": "yarn copy:navbar; yarn copy:sidebar; yarn copy:searchbox; vuepress build docs"
+    "docs:build": "yarn copy:navbar; yarn copy:sidebar; yarn copy:searchbox; vuepress build docs",
+    "format": "prettier --write ./**/*.{js,vue,md,json,yaml} --loglevel silent"
   },
   "devDependencies": {
     "@api3/airnode-abi": "^0.1.0",
@@ -29,6 +30,7 @@
     "file": "^0.2.2",
     "markdown-link-check": "^3.8.6",
     "oust": "^1.2.0",
+    "prettier": "^2.4.1",
     "v-click-outside": "^3.1.2",
     "vuepress": "^1.8.2",
     "vuepress-plugin-element-tabs": "^0.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6789,6 +6789,11 @@ prettier@^1.18.2:
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+
 pretty-error@^2.0.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz"


### PR DESCRIPTION
I've added prettier support (and a script to package.json) which formats the files in the project.

This works mostly fine, but it treats the files as `md` files and doesn't understand some of the vuepress specific stuff (e.g. tabs). 
However, I didn't find any vue specific feature which would be broken by the formatting (you mostly need to add newlines somewhere).

Even if there was some section that should not be formatted, you can exclude it from prettier: https://prettier.io/docs/en/ignore.html

I didn't format anything just yet not to create any conflicts for you. We can reformat the stuff gradually. (This also means you shouldn't run the `format` script, because that tries to format all files in the project).