### PR TITLE
Sponsor wallet xpub error messages

### DIFF
--- a/docs/airnode/next/concepts/README.md
+++ b/docs/airnode/next/concepts/README.md
@@ -27,6 +27,7 @@ The [AirnodeRrp.sol](https://github.com/api3dao/airnode/blob/master/packages/pro
 
 The [Admin](../admin-cli-commands.md) (`@api3/airnode-admin`) package is a CLI tool used to interact with `AirnodeRrp.sol` and perform administrative actions. See the [admin package](https://github.com/api3dao/airnode/tree/master/packages/admin) in GitHub.
 
+<Fix>Out-of-date: it should now inherit from RrpRequester.sol</Fix>
 To use AirnodeRrp.sol a requester must import AirnodeRrpClient.sol.
 
 `import "@api3/airnode-protocol/contracts/AirnodeRrpClient.sol";`

--- a/docs/airnode/next/concepts/airnode.md
+++ b/docs/airnode/next/concepts/airnode.md
@@ -32,23 +32,20 @@ airnodeAddress = airnodeHdNode.address;
 ```
 
 ## `xpub`
-
-The Airnode owner announces their extended public key (`xpub`) as stored in `AirnodeParameterStore.sol` for sponsors to be able to derive their sponsor wallets. The `xpub` that the owner has announced is not verified on-chain. However, the sponsor can verify it off-chain. For example, in JS (using ethers.js):
+The Airnode owner announces off-chain their extended public key (`xpub` of the hardened derivation path `m/44'/60'/0'`) for sponsors to be able to derive their sponsor wallets. This wallet will then be used by the Airnode to fulfill each request made by the requester contracts. The `xpub` that the owner has announced is not verified on-chain. However, the sponsor can verify it off-chain. For example, in JS (using ethers.js):
 
 ```js
+// airnodeAddress is the address of the default derivation path 
+// of the Airnode operator wallet m/44'/60'/0'/0/0 
 hdNode = ethers.utils.HDNode.fromExtendedKey(xpub);
-masterNode = hdNode.derivePath('m');
-airnodeAddressDerivedFromXpub = keccak256(abi.encode(masterNode.address));
-assert(airnodeAddressDerivedFromXpub === airnodeAddress);
+assert(airnodeAddress === hdNode.derivePath('0/0').address);
 ```
 
 See the [section about sponsor wallets](sponsor-wallet.md) to see how sponsors can use `xpub` to derive their sponsor wallets.
 
-## `setAirnodeXpub()`
-<Fix>Add content about `setAirnodeXpub()`.</Fix> 
-
 ## Setting endpoint authorizers
-<Fix>airnodeAdmin is no longer used. What (if anything) replaces it here?</Fix>
+<Fix>airnodeAdmin is no longer used. What (if anything) replaces it here? Answer: there is no longer the concept of an admin for AirnodeRrp but we still have the airnode operator which is the one that holds the mnemonic used while deploying the Airnode. Anyone can make requests, create templates and withdraw from sponsor wallet and there no longer any parameters being set on-chain so no need for admin.</Fix>
 <Fix>This should probably be removed and addressed in Authorizers.</Fix>
-An important responsibility of the ~~`airnodeAdmin`~~ is to set endpoint authorizers. Authorizers are used to enforce rules about which requests will be responded to, and this can be used to enforce KYC, monthly subscription payments, etc. See the sections about [endpoints](endpoint.md) and [authorizers](authorization.md) for more details.
+Answer: yes. The statement is correct but it's probably already addressed in authorization.md
+~~An important responsibility of the `airnodeAdmin` is to set endpoint authorizers.~~ Authorizers are used to enforce rules about which requests will be responded to, and this can be used to enforce KYC, monthly subscription payments, etc. See the sections about [endpoints](endpoint.md) and [authorizers](authorization.md) for more details.
 

--- a/docs/airnode/next/concepts/sponsor.md
+++ b/docs/airnode/next/concepts/sponsor.md
@@ -37,19 +37,18 @@ Note that a sponsor could use multiple addresses from multiple wallets. Below ar
 
 ## sponsorWallet
 
-Each [Airnode](Airnode.md) can keep a unique`sponsorWallet` for a [sponsor](sponsor.md). The wallet is identified by a `sponsorAddress/airnodeAddress` pair. A sponsor must take action to [derive](sponsor.md#derive-a-sponsor-wallet) a `sponsorWallet` for a particular Airnode. [Requesters](requester.md), that have been  [sponsored](sponsorship.md) by a sponsor, can specify their requests be fulfilled by the  `sponsorWallet` belonging to the sponsor. This allows the sponsor to cover the gas cost of request fulfillments by the Airnode.
+Each [Airnode](Airnode.md) can keep a unique`sponsorWallet` for a [sponsor](sponsor.md). The wallet is identified by a `sponsorAddress/airnodeAddress` pair. A sponsor must take action to [derive](sponsor.md#derive-a-sponsor-wallet) a `sponsorWallet` for a particular Airnode. [Requesters](requester.md), that have been  [sponsored](sponsorship.md) by a sponsor, can specify their requests be fulfilled by the  `sponsorWallet` designated to the sponsor. This allows the sponsor to cover the gas cost of request fulfillments by the Airnode since the sponsor must send funds to this wallet before making the request.
 
 ### Derivation Path
-<Fix>1-Needs review, this is in AN-96.</Fix>
-Each sponsor is identified by a `sponsorAddress`, and their sponsor wallets are designated implicitly by a derivation path. The derivation path for a `sponsorWallet` starts with m/0/.... The zero here is allocated for RRP, and the other branches will be used to derive the sponsor wallets for other protocols such as PSP.
+Each sponsor is identified by a `sponsorAddress`, and their sponsor wallets are designated implicitly by a derivation path. The derivation path for a `sponsorWallet` starts with `m/44'/60'/0'/0/...` The zero here is allocated for RRP, and the other branches will be used to derive the sponsor wallets for other protocols such as PSP.
 
-The path of a `sponsorWallet` for the request–response protocol is `m/0/${sponsorAddress}`. This means that we assume that `sponsorAddress` will be less than `2^31` (yet this can be extended by using schemes such as `m/0/${sponsorAddress % 2^31}/${sponsorAddress / 2^31}`). Other branches such as `m/1/...`, `m/2/...`, etc. are reserved for other protocols (e.g., the pub–sub protocol).
+The path of a `sponsorWallet` for the request–response protocol is `m/44'/60'/0'/0/${sponsorAddress}`. Other branches such as `m/44'/60'/0'/1/...`, `m/44'/60'/0'/2/...`, etc. are reserved for other protocols (e.g., the pub–sub protocol).
 
-An Ethereum address is 20 bytes-long, which makes 160 bits. Each index in the HD wallet non-hardened derivation path goes up to 2^31. Divide these 160 bits into six 31 bit-long chunks and the derivation path for a sponsor wallet of a requester would be:
+An Ethereum address is 20 bytes-long, which makes 160 bits. Each index in the HD wallet non-hardened derivation path goes up to 2^31. This means that we must divide these 160 bits into six 31 bit-long chunks and the derivation path for a sponsor wallet of a requester would be:
 
 `m / 0 / sponsor && 0x7FFFFFFF / (sponsor >> 31) && 0x7FFFFFFF / (sponsor >> 62) && 0x7FFFFFFF / (sponsor >> 93) && 0x7FFFFFFF / (sponsor >> 124) && 0x7FFFFFFF / (sponsor >> 155) && 0x7FFFFFFF`
 
-Anyone can use the xpub that the Airnode has announced (through on-chain or off-chain channels) and the sponsor's `sponsorAddress` to derive a `sponsorWalletAddress` for a specific Airnode–sponsor pair. In other words, a sponsor can calculate the address of their respective sponsor wallet for an Airnode and have requesters use it to make requests right away.
+Anyone can use the xpub that the Airnode has announced (through off-chain channels) and the sponsor's `sponsorAddress` to derive a `sponsorWalletAddress` for a specific Airnode–sponsor pair. In other words, a sponsor can calculate the address of their respective sponsor wallet for an Airnode and have requesters use it to make requests right away.
 
 ### Gas Costs
 
@@ -77,6 +76,6 @@ Use the [Admin CLI tool](../admin-cli-commands.md#sponsor-requester) to sponsor 
 
 ## Derive a Sponsor Wallet
 
-When a sponsor wishes to access an Airnode (via a requester) it must create a `sponsorWallet` for the Airnode. Requesters that have been sponsored by the same sponsor, can specify their requests be fulfilled by the `sponsorWallet` belonging to the sponsor. A sponsor uses a [`sponsorAddress`](sponsor.md#sponsoraddress) and the [`airnodeAddress`](airnode.md#airnodeaddress) of a particular Airnode to derive a [sponsorWallet](sponsor-wallet.md) for the Airnode.
+When a sponsor wishes to access an Airnode (via a requester) it must create a `sponsorWallet` for the Airnode. Requesters that have been sponsored by the same sponsor, can specify their requests be fulfilled by the `sponsorWallet` belonging to the sponsor. A sponsor uses a [`sponsorAddress`](sponsor.md#sponsoraddress) and the [`xpub`](airnode.md#xpub) of a particular Airnode to derive a [sponsorWallet](sponsor-wallet.md) for the Airnode. The sponsor must also provide the [`airnodeAddress`](airnode.md#airnodeaddress) because it will be used to verify that the provided xpub belongs to the Airnode wallet before deriving a child sponsor wallet address.
 
 Use the [Admin CLI tool](../admin-cli-commands.md#derive-sponsor-wallet-addfress) to derive a `sponsorWallet`. An example can be seem in the [Requesters and Sponsors](../../grp-developers/requesters-sponsors.md#how-to-derive-a-sponsor-wallet) doc.

--- a/docs/airnode/next/grp-developers/call-an-airnode.md
+++ b/docs/airnode/next/grp-developers/call-an-airnode.md
@@ -49,7 +49,7 @@ There are three types of requests provided by the AirnodeRrp.sol contract. See [
 
 This example will use a [full request](../reference/concepts/request.md#_3-full-request) type (note the `airnode.makeFullRequest` function call in the code below) which is called from the requester's own function `callTheAirnode`. The function `makeFullRequest` requires that the requester pass all parameters needed by Airnode to call its underlying API.
 
-Once the request has been made to `airnode.makeFullRequest` the AirnodeRrp.sol contract will return a `requestId` confirming the request has been accepted and is in process of being executed. Your requester would most likely wish to track all requestIds. Note the line `incomingFulfillments[requestId] = true;` in the code below that stores the requestIds in a mapping. This will be useful when the Airnode responds to the requester later at the function (`airnodeCallback`) with the requestId, statusCode and the data requested.
+Once the request has been made to `airnode.makeFullRequest` the AirnodeRrp.sol contract will return a `requestId` confirming the request has been accepted and is in process of being executed. Your requester would most likely wish to track all requestIds. Note the line `incomingFulfillments[requestId] = true;` in the code below that stores the requestIds in a mapping. This will be useful when the Airnode responds to the requester later at the function (`airnodeCallback`) with the `requestId` and the `data` requested.
 
 ```solidity
 import "@api3/protocol/contracts/rrp/requesters/RrpRequester.sol";
@@ -86,7 +86,6 @@ contract MyRequester is RrpRequester {
   
   function airnodeCallback(   // The AirnodeRrp.sol protocol contract will callback here.
       bytes32 requestId,
-      uint256 statusCode,
       bytes calldata data
   { 
       ...
@@ -133,7 +132,7 @@ For additional information on request parameters when calling `airnode.makeFullR
 
 ## Step #3: Capture the Response
 
-As soon as the Airnode gets a request it will gather the data and start an on-chain transaction responding to the request. The Airnode calls the AirnodeRrp.sol contract function `fulfill()` which in turn will call the requester, in this case, at `airnodeCallback`. Recall the request supplied the request contract address and the desired callback function which the AirnodeRrp.sol protocol contract stored with the requestId for the purpose of the callback.
+As soon as the Airnode gets a request it will gather the data and start an on-chain transaction responding to the request. The Airnode calls the AirnodeRrp.sol contract function `fulfill()` which in turn will call the requester, in this case, at `airnodeCallback`. Recall the request supplied the request contract address and the desired callback function which the AirnodeRrp.sol protocol contract stored with the `requestId` for the purpose of the callback.
 
 ```solidity
 import "@api3/protocol/contracts/rrp/requesters/RrpRequester.sol";
@@ -153,7 +152,6 @@ contract MyRequester is RrpRequester {
 
     function airnodeCallback(        // The AirnodeRrp.sol protocol contract will callback here.
         bytes32 requestId,
-        uint256 statusCode,
         bytes calldata data
         )
         external
@@ -162,9 +160,7 @@ contract MyRequester is RrpRequester {
         require(incomingFulfillments[requestId], "No such request made");
         delete incomingFulfillments[requestId];
         int256 decodedData = abi.decode(data, (int256));
-        if (statusCode == 0) {
-            fulfilledData[requestId] = decodedData;
-        }
+        fulfilledData[requestId] = decodedData;
     }
 }
 ```
@@ -174,8 +170,6 @@ contract MyRequester is RrpRequester {
 The callback to a requester will contain three parameters.
 
 - **requestId**: First acquired when making the request and passed here as a reference to identify which request the response is for.
-- **statusCode**: A statusCode of `0` indicates a successful response and a `non-0` statusCode an error. See [statusCode](../reference/concepts/request.md#statuscode) for a list of error statusCodes.
-
 - **data**: For a successful response the requested data which has been encoded. Decode it using the function `decode()` from the `abi` object .
 
 

--- a/docs/airnode/next/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/next/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -175,6 +175,7 @@ The `nodeSettings.cloudProvider` field indicates which cloud provider Airnode sh
 There are plans to extend the deployer-image to support a wide variety of cloud providers. If you would like to contribute, please join the conversation in [this issue](https://github.com/api3dao/airnode/issues/154).
 
 #### airnodeWalletMnemonic
+<Fix>I don't think this is still optional</Fix>
 (optional) An API provider can provide a mnemonic to be used as the Airnode's BIP 44 wallet from which the Airnode's [`address`](../../../concepts/airnode.md#airnodeaddress) will be derived. If a mnemonic is not provided the deployer will create one for the Airnode. It is not required to fund the wallet to run the Airnode but must be funded to announce the [`xpub`](../../../concepts/airnode.md#xpub) of the Airnode on-chain which is optional.
 
 #### region

--- a/docs/airnode/next/reference/admin-cli-commands.md
+++ b/docs/airnode/next/reference/admin-cli-commands.md
@@ -156,17 +156,15 @@ npx @api3/airnode-admin get-sponsor-status \
 
 ### `derive-sponsor-wallet-address`
 
-Derives a [sponsorWallet](../concepts/sponsor.md#sponsorwallet) designated by an Airnode for a sponsor and returns the address of the wallet. 
+Derives a [sponsorWallet](../concepts/sponsor.md#sponsorwallet) designated by an Airnode for a sponsor and returns the address of the wallet. The `airnode-xpub` must belong to the HDNode with the path `m/44'/60'/0'` of the Airnode wallet.
 
-- `provider-url`: A valid cloud provider URL.
+- `airnode-xpub`: The extended public address of the Airnode.
 - `airnode-address`: The public address of the Airnode.
-- `sponsor-address`: Use the `sponsorAddress`, returned by the  [`sponsor-requester`](admin-cli-commands.md#sponsor-requester) command, to create a [relationship](../concepts/sponsor.md) between the requester and this `sponsorWallet`. More than one requester can use the same sponsor's `sponsorWallet` of an Airnode.
-- `airnode-rrp (optional)`: The public address of the AirnodeRrp.sol protocol contract.
-- `xpub (optional)`: The extended public address of the Airnode. Normally the `airnode-address` parameter is used to look-up up the Airnode's `xpub`. If the Airnode operator has not announced the `xpub` on-chain it will be necessary to supply this value.
+- `sponsor-address`: The address of the sponsor wallet.
 
 ```sh
 npx @api3/airnode-admin derive-sponsor-wallet-address \
-  --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> \
+  --airnode-xpub xpub6CUGRUo... \
   --airnode-address 0xe1e0dd... \
   --sponsor-address 0x9Ec6C4...
 ```
@@ -249,41 +247,7 @@ npx @api3/airnode-admin check-withdrawal-request \
 
 Helper commands for a previously deployed Airnode. These commands connect to the AirnodeRrp.sol protocol contract.
 
-- [set-airnode-xpub](admin-cli-commands.md#set-airnode-xpub)
-- [get-airnode-xpub](admin-cli-commands.md#get-airnode-xpub)
 - [derive-endpoint-id](admin-cli-commands.md#derive-endpoint-id)
-
-<divider/>
-
-### `set-airnode-xpub`
-
-Sets the [xpub](../concepts/airnode.html#xpub) of an Airnode (optional). The xpub (extended public key) does not need to be announced on-chain for the protocol to be used, it is mainly for convenience. 
-
-- `provider-url`: A valid cloud provider URL.
-- `mnemonic`: The Airnode's mnemonic which was declared when the Airnode was created, see [`nodeSettings.airnodeWalletMnemonic`](./deployment-files/config-json.md#nodesettings). The xpub will be derived from this mnemonic. Also used to pay gas cost for this command's transaction.
-- `airnode-rrp (optional)`: The public address of the AirnodeRrp.sol protocol contract.
-
-```sh
-npx @api3/airnode-admin set-airnode-xpub \
-  --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> \
-  --mnemonic "nature about salad..."
-```
-
-<divider/>
-
-### `get-airnode-xpub`
-
-Returns the Airnode xpub for the given `airnode`.
-
-- `provider-url`: A valid cloud provider URL.
-- `airnode-address`: The public address of the Airnode.
-- `airnode-rrp (optional)`: The public address of the AirnodeRrp.sol protocol contract
-
-```sh
-npx @api3/airnode-admin get-airnode-xpub \
-  --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> \
-  --airnode-address 0xe1e0dd...
-```
 
 <divider/>
 

--- a/docs/airnode/next/reference/deployment-files/receipt-json.md
+++ b/docs/airnode/next/reference/deployment-files/receipt-json.md
@@ -8,6 +8,8 @@ A `receipt.json` file is outputted after each deployment and contains non-sensit
 The main use of a receipt file is to remove an Airnode deployment when no longer needed. Use the [docker
 image](../../grp-providers/guides/docker/deployer-image.html#remove) to execute the remove command.
 
+It also provides the Airnode xpub for the hardened derivation path `m/44'/60'/0'` that must be announced off-chain in order for sponsors to derive their designated sponsor wallet. This wallet will then be used by the Airnode to fulfill each request made by the requester contracts.
+
 - `airnodeWallet`: describes the Airnode that was deployed
 - `deployment`: where the Airnode was deployed to
 - `api`: contains the details of the Airnode API (e.g.
@@ -19,12 +21,12 @@ Example receipt:
 ```json
 {
   "airnodeWallet": {
-    "airnodeAdress": "0x23722bcdd23e559d7151db284f290fadde9f3cb725859d476ef1f16ab315355e",
-    "airnodeAddressShort": "23722b",
-    "xpub": "xpub661MyMwAqRbcFgefUsJa8UarHveV9dgvW6bKF13GaJFrw7AAcHCtMVuy3ZkFrTWdW2ji9TdjGHFbf3qk9vWvcNVPVZCtDGyASNs2V5SKcmf"
+    "airnodeAddress": "0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace",
+    "airnodeAddressShort": "a30ca71",
+    "airnodeXpub": "xpub6C8tvRgYkjNVaGMtpyZf4deBcUQHf7vgWUraVxY6gYiZhBYbPkFkLLWJzUUeVFdkKpVtatmXHX8kB76xgfmTpVZWbVWdq1rneaAY6a8RtbY"
   },
   "deployment": {
-    "airnodeAdressShort": "23722b",
+    "airnodeAddressShort": "a30ca71",
     "cloudProvider": "aws",
     "region": "us-east-1",
     "stage": "starter-example",


### PR DESCRIPTION
I fixed documentation related to:
1. airnode xpub
2. derivation path for sponsor wallet
3. updates to protocol on `fulfill()` and `fail()` (signature and error messages)

There is at least 1 image which needs to be updated and I added a few <Fix> tags. I also answered some other <Fix> tags that were already there in the docs.