### PR TITLE
Sub-sites locking issue - API3 Intro

### DIFF
--- a/docs/.vuepress/components/SubSites.vue
+++ b/docs/.vuepress/components/SubSites.vue
@@ -1,11 +1,15 @@
 <!--
 This component places icons (sub-sites) in the header of the sidebar. 
+
+NOTE: When this component is MOUNTED (as it is mounted from a landing page click),
+it will alwasy set this.lastVisited to the config.js latestVersion var. Therefor
+it is normal behavior to force the user to the lastest version of airnode.
 -->
 
 <template>
   <div>
     <div v-if="isMounted" class="container" style="font-size:medium;">
-        <router-link class="route-link" :to="currentVersionPath" v-bind:class="{ selectedButton: btnAirnode }">
+        <router-link class="route-link" :to="{ path: lastVisited }" v-bind:class="{ selectedButton: btnAirnode }">
           <font-awesome-icon icon="sitemap" size="2x"/>
           <br/><span style="font-size:14px;">Airnode</span>
         </router-link>
@@ -23,6 +27,7 @@ This component places icons (sub-sites) in the header of the sidebar.
 </template>
 
 <script>
+  
   import Vue from 'vue'
   import { library, icon } from '@fortawesome/fontawesome-svg-core'
   import { faUsers } from '@fortawesome/free-solid-svg-icons'
@@ -32,18 +37,17 @@ This component places icons (sub-sites) in the header of the sidebar.
   import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
   Vue.component('font-awesome-icon', FontAwesomeIcon)
   library.add(faBars, faUsers, faSitemap, faEye)
+  import { latestVersion } from '../config.js'
 
   export default {
     name: 'sub-sites',
-    data () {
-      return {
-        currentVersionPath: '',
-        btnAPI3: false,
-        btnMembers: false,
-        btnAirnode: false,
-        isMounted: false // When the page is mounted show icons to avoid flickering 
-      }
-    },
+    data: () => ({
+      lastVisited: latestVersion,
+      btnAPI3: false,
+      btnMembers: false,
+      btnAirnode: false,
+      isMounted: false // When the page is mounted show icons to avoid flickering 
+    }),
     watch: {
       '$route'($event) {
         this.selectIcon();
@@ -59,22 +63,24 @@ This component places icons (sub-sites) in the header of the sidebar.
         }
         else if(this.$route.path.indexOf('/airnode/') > -1){
           this.btnAirnode = true
-          // Set the currentVersionPath
-          let arr = this.$route.path.split('/')
-          this.currentVersionPath = '/'+arr[1]+'/'+arr[2]+'/'
+          this.setLastVersionVisited()
         }
         else if(this.$route.path.indexOf('/api3/') > -1){
           this.btnAPI3 = true
         }
       },
+      setLastVersionVisited() {
+        if(this.$route.path.indexOf('/airnode/') > -1){
+          let arr = this.$route.path.split('/')
+          this.lastVisited = '/'+arr[1]+'/'+arr[2]+'/'
+        }
+      },
     },
     mounted() {
       this.$nextTick(function () {
-        // Code that will run only after the
-        // entire view has been rendered
+        // Code that will run only after the entire view has been rendered
         this.selectIcon();
         this.isMounted = true;
-        //console.log('this.$nextTick > $route.path', this.$route.path)
       })
     }
   }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,6 +6,11 @@ module.exports = {
   versions:[
     {name:'pre-alpha', url:'/airnode/pre-alpha/'},
   ],
+  /**
+   * Indicates the path to the latest Airnode version.
+   * Used by sub-sites component.
+   */
+  latestVersion: '/airnode/pre-alpha/',
   head: [
     ['link', { rel: 'icon', href: '/img/small-logo.png' }]
   ],

--- a/docs/airnode/next/sidebar.js
+++ b/docs/airnode/next/sidebar.js
@@ -3,7 +3,7 @@ module.exports = [
     title: 'Introduction', initialOpenGroupIndex: 0, collapsable: true,
     children: [
       '',
-      'introduction/why-use-airnode'
+      //'introduction/why-use-airnode'
     ]
   },
   {

--- a/docs/airnode/pre-alpha/sidebar.js
+++ b/docs/airnode/pre-alpha/sidebar.js
@@ -3,7 +3,7 @@ module.exports = [
     title: 'Introduction', collapsable: false, 
     children: [
         '',
-        'introduction/why-use-airnode',
+        //'introduction/why-use-airnode',
     ]
   },
   {

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -67,19 +67,28 @@ The **/next** and **/dev** folders are routes that are not listed in the version
 
 It is assumed that the **/next** folder is the work in progress that will become the new (next) version.
 
-1. Make a copy of the **/next** folder and name it (e.g. v1).
+1. Change the name of the **/next** folder (e.g. v1.0).
 
-2. Update the **versions** key in .vuepress/config.json. Provide the version name and url. The url is the first markdown file to show when a version is selected in the navbar. A url without a file will load the root README.md file of the base route by default.
+2. Changes to `config.js`. 
+ 
+     - Update the `versions` key in .vuepress/config.json. Provide the version name and url. The url is the first markdown file to show when a version is selected in the navbar. A url without a file will load the root README.md file of the base route by default.
+     - Set the `latestVersion` to the start path of the latest version.
+     - Set the `themeConfig.startPath` to the start path of the latest version.
 
     ```json
     versions:[
-      {name:'v1', url:'/airnode/v1/'},
+      {name:'v1', url:'/airnode/v1.0/'},
       {name:'pre-alpha', url:'/airnode/pre-alpha/'},
       ...
     ],
+    latestVersion: '/airnode/pre-alpha/',
+    ...
+    themeConfig:{
+      startPath:'/airnode/pre-alpha/',
+    }
     ```
 
-3. The **/next** version probably contained hyperlinks to remote GitHub repos. More than likely these links will need updating in the version just created.
+3. The re-named `/next` version will probably contained hyperlinks to remote GitHub repos. More than likely these links will need updating in the version just created.
 
 4. Point all [redirects](versioning.md#redirects), when relevant, to the new version in the `docs/.vuepress.redirects` file. Usually this is related to redirects for items such as `/latest/members` that want to display docs for the latest version. Be mindful of any redirects with `/next` in the path.
 


### PR DESCRIPTION
The sub-sites would lock up the Airnode icon when the user returned to the landing page from the DAO Members or API3 btn.
The page Why us Airnode is blocking 2 JIRAs so I have commented it out in the sidebars for `/next` and `/pre-alpha` until it is ready.