### PR TITLE
AN-301 and AN-305

### DIFF
--- a/docs/airnode/v1.0/concepts/airnode-auth.md
+++ b/docs/airnode/v1.0/concepts/airnode-auth.md
@@ -11,7 +11,7 @@ API providers can instruct Airnode to authenticate requests to their endpoints. 
 
 >![airnode-auth](../assets/images/concepts-airnode-auth.png)
 
-[OpenAPI](https://swagger.io/docs/specification/authentication/) uses the term **security scheme** for authentication and authorization schemes. Airnode only uses standard OAS defined authentication schemes to identify itself to API endpoints. Airnode supports two types of authentication, `http` and `apiKey`.
+[OAS OpenAPI Specification](https://swagger.io/docs/specification/authentication/) uses the term **security scheme** for authentication and authorization schemes. Airnode only uses standard OAS defined authentication schemes to identify itself to API endpoints. Airnode supports two types of authentication, `http` and `apiKey`.
 
 - HTTP authentication schemes (using the `Authorization` header) supported by Airnode:
   - [Basic](https://swagger.io/docs/specification/authentication/basic-authentication/)

--- a/docs/airnode/v1.0/grp-providers/guides/build-an-airnode/api-integration.md
+++ b/docs/airnode/v1.0/grp-providers/guides/build-an-airnode/api-integration.md
@@ -19,33 +19,30 @@ A successful integration of an API with an Airnode requires the mapping of each 
 
 OIS is a mapping of API operations, such as  `GET /coins/{id}`, to Airnode endpoints. When a requester contract calls a AirnodeRrp.col contract request function, such as `makeFullRequest(..., callData)`, the callData is communicated to the off-chain Airnode which uses OIS mappings to translate the callData into a valid HTTP request for the appropriate API operation.
 
-Therefore, only thing needed to integrate an API to Airnode is to create an OIS object which is in the Airnode's `config.json` file. This guide is an instructive approach to creating an OIS. As a point of reference, refer to [Oracle Integration Specifications (OIS)](../../../reference/specifications/ois.md) in the Reference section of these docs for additional input and understanding. It may be useful, but not necessary, to reference the [OpenAPI Specification (OAS) 3.0.3 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) about fields related to API specifications.
+The only thing needed to integrate an API to Airnode is to create an OIS object which is in the Airnode's `config.json` file. This guide is an instructive approach to create an OIS object. OIS borrows formatting from [OAS OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md). If you have experience with OAS, OIS will seem familiar.
 
-::: tip Specification Conversion
-To assist in converting between various specifications e.g. from OAS to OIS, there is a `convert` command within the Airnode [validator](https://github.com/api3dao/airnode/tree/master/packages/validator#airnodeconvertor) package.
+::: tip OAS
+It is not recommended to refer to OAS for help while creating your OIS object. OIS only borrows formatting practices from OAS. Everything needed to create an OIS object is in these docs. 
 :::
 
-<!-- markdownlint-disable -->
-<details class="collapse-box">
-  <summary class="collapse-box-summary">
-  Other tips while this guide.
-  </summary>
-  
-  - Open the [OIS template](../../../reference/templates/ois-json.md) in another browser window to follow along.
+**Tips while using this guide.**
 
-  - View an example of an [Airnode config.json file](../../tutorial/config-json.md) from the Airnode Starter tutorial.
+- Open the [OIS template](../../../reference/templates/ois-json.md) in another browser window to follow along.
+- View an example of an [Airnode config.json file](../../../reference/examples/config-json.md) from the Airnode Starter tutorial.
 
-</details>
-<!-- markdownlint-enable -->
 
 
 ## OIS Template
 
-An _OIS_ is a json object that is added to an Airnode's [config.json](../../../reference/templates/config-json.md) file as the (`ois`) _key_, sometimes called a _field_. Try using the [OIS template](../../../reference/templates/ois-json.md) to construct an OIS and add it to the Airnode's config.json file later.
+OIS is a json object that is added to an Airnode's [config.json](../../../reference/templates/config-json.md) file as the (`ois`) _key_, sometimes called a _field_. Try using the [OIS template](../../../reference/templates/ois-json.md) to construct an OIS and add it to the Airnode's config.json file later.
 
 In the OIS template, there are some fields that contain `{FILL_*}`. This means that the value added is independent from other fields. On the other hand, if two fields contain the same expression  (e.g., `{FILL_OPERATION_PARAMETER_1_NAME}`), you must use the same value in them, because they are referencing each other.
 
-OIS uses a simplified version of the [OpenAPI Specification (OAS)](https://github.com/OAI/OpenAPI-Specification). This means that if you have the OpenAPI/Swagger specifications of the API that you are going to integrate, you are about 80% done, because you can copy paste entire sections (but make sure that you make the necessary modifications to conform to the OIS format).
+OIS uses a simplified version of the OAS. This means that if you have the OpenAPI specifications of the API that you are going to integrate, you are about 80% done, because you can copy paste entire sections (but make sure that you make the necessary modifications to conform to the OIS format).
+
+::: tip 
+If you already have an OAS file it may be possible to convert it to OIS. To assist in converting between various specifications e.g. from OAS to OIS, there is a `convert` command within the Airnode [validator](https://github.com/api3dao/airnode/tree/master/packages/validator#airnodeconvertor) package. 
+:::
 
 This guide will assume you do not have the OpenAPI specifications of the API that you will be integrating.
 
@@ -260,10 +257,13 @@ Security is implemented using the securitySchemes and security fields. You use `
       "name": "X-api-key" // Arbitrary name
     }
   }
+},
+"security": {
+  "myApiKeyScheme": []
 }
 ```
 
-You can create a securityScheme by copying the code above or using the template code below. Just follow the steps below. Or use the full [OIS Template](../../../reference/templates/ois-json.md). 
+You can create a securityScheme by copying the code above, using the template code below or use the full [OIS Template](../../../reference/templates/ois-json.md). The proceed to follow the steps below. 
 
 ```json
 "components": {
@@ -271,31 +271,59 @@ You can create a securityScheme by copying the code above or using the template 
     "<FILL_SECURITY_SCHEME_NAME>": {
       "in": "<FILL_*>",
       "type": "<FILL_*>",
-      "name": "<FILL_*>"
+      "name": "<FILL_*>",
+      "scheme":"<FILL_*>"
     }
   }
 }
+"security": {
+  "<FILL_SECURITY_SCHEME_NAME>": []
+}
 ```
 
-1. First, name the security scheme by replacing `{FILL_SECURITY_SCHEME_NAME}` under `apiSpecifications.components.securitySchemes`. Note that you will also need to use the same name under `apiSpecifications.security`. Make sure to choose a descriptive name, such as `myApiKeyScheme`. This name will also be referred in the [secrets.env](../../../reference/deployment-files/secrets-env.md) file in a later step.
+1. First, name the security scheme by replacing `{FILL_SECURITY_SCHEME_NAME}` under `apiSpecifications.components.securitySchemes`. Note that you will also need to use the same name under `apiSpecifications.security`. Make sure to choose a descriptive name, such as `myApiKeyScheme`. Its value will be referenced using the apiCredential field in `config.json` later in [Configuring Airnode](./configuring-airnode.md#apicredentials).
 
     > Note that we will not be entering the API key itself in the OIS, because the OIS is not meant to include any user-specific information. Security credentials such as API keys go in [secrets.env](../../../reference/deployment-files/secrets-env.md) file.
 
-2. Enter values for `in`, `type` and `name`. You can refer to the [OIS](../../../reference/specifications/ois.md#_4-2-components) document for more details or reference the following table for acceptable values.
+2. Enter values for `type`, `in`, `name` and `scheme`. You can refer to the [OIS](../../../reference/specifications/ois.md#_4-2-components) document for more details or reference the following table for examples.
 
-    | type        | in           | name     |
-    | ----------- | ------------ | -------- |
-    | apiKey      | header       | {myName}, Arbitrary parameter name |
-    | http        | query        |          |
-    |             | cookie       |          |
+      ```json
+      "myApiKeyScheme": {
+        "in": "header",
+        "type": "apiKey",
+        "name": "X_api_key",
+      },
+      "myHttpBasicScheme": {
+        "type": "http",
+        "scheme": "basic",
+      },
+      "myHttpBearerScheme": {
+        "type": "http",
+        "scheme": "bearer",
+      }
+      ```
 
-3. Security credentials such as API keys go in [secrets.env](../../../reference/deployment-files/secrets-env.md) file. This step will actually be discussed in the next Guide document [Configuring Airnode](configuring-airnode.md#creating-secrets-env) which will discuss how to link your securityScheme(s) to the secrets.env file via the environment field. For now the following shows what the type `apiKey` named `myApiKeyScheme` might look like in secrets.env.
+3. Security credentials such as API keys go in [secrets.env](../../../reference/deployment-files/secrets-env.md) file. This step will actually be discussed in the next Guide document [Configuring Airnode](configuring-airnode.md#creating-secrets-env) which will discuss how to link your securityScheme(s) to the secrets.env file via the `apiCredential` field. For now the following shows what the type `apiKey` named `myApiKeyScheme` might look like in secrets.env.
 
     ```bash
     AIRNODE_WALLET_MNEMONIC=""
     CP_EVM_31337_EVM_LOCAL=""
-    SS_MY_API_KEY="XP9876BH768FGD6734" # The apiKey
+    SS_MY_API_KEY_SCHEME="XP98...D6734" # The apiKey
     ```
+#### Security Field
+
+The `security` field lists all security scheme names that are used by the API in `components.securitySchemes`. A future release of Airnode will allow the use of `security` to assign different security schemes to individual API operations. For now its value must be an empty array. 
+
+::: warning Please note:
+Currently Airnode reads the security schemes from `component.securitySchemes` and not `security`. Using the `security` field now provides for a smooth transition to future releases of Airnode with regards to security scheme implementation.
+:::
+
+#### API Operations needing different securitySchemes
+
+For this release of Airnode, if different API operations use different securitySchemes (or some use none) they must be grouped in different OIS objects based on their common securityScheme(s). For example: Your API has four operations, three require an apiKey in the HTTP header, another (`/ping`) requires no security. As noted previously, this will change in a future release of Airnode.
+
+- The first three API operations might be in the `ois[0]` object with a securityScheme named _myApiKeyScheme_ of type _apiKey_ as shown above. 
+- The /ping API operation would be in `ois[1]` which would not have any `component.securitySchemes` and `security` would be an empty array.
 
 #### Multiple securitySchemes
 
@@ -305,29 +333,26 @@ You can use multiple security schemes (e.g., an API key goes in the header, and 
   "components": {
     "securitySchemes": {
       "myApiKeyScheme": {
-        "in": "header",
         "type": "apiKey", 
+        "in": "header",
         "name": "X-api-key"
       },
       "mySecretScheme": {
-        "in": "query",
         "type": "apiKey",
+        "in": "query",
         "name": "secret"
       }
     }
+  },
+  "security": {
+    "myApiKeyScheme": [],
+    "mySecretScheme": []
   }
   ```
 
-#### API Operations needing different securitySchemes
-
-If different API operations use different securitySchemes (or some use none) they must be grouped in different `ois` objects based on their common securityScheme(s). For example: Your API has four operations, three require an apiKey in the HTTP header, another (`/ping`) requires no security. 
-
-- The first three API operations might be in the `ois[0]` object with a securityScheme named _myApiKeyScheme_ of type _apiKey_ as shown above. 
-- The /ping API operation would be in `ois[1]` which would not have any `component.securitySchemes` and `security` would be an empty array.
-
 #### No Security
 
-If the API you are integrating is publicly accessible, you can remove all security schemes.
+If the API you are integrating is publicly accessible, you can set both the `securitySchemes` and `security` fields to empty objects.
 
 <!--------------- STEP 3 ---------------->
 

--- a/docs/airnode/v1.0/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v1.0/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -202,7 +202,7 @@ The `ois` field is a list OIS objects that Airnode will be serving. This means t
 
 ### apiCredentials
 
-Each entry in `apiCredentials` maps to a security scheme defined in an OIS (`ois[n].components.securitySchemes.{securitySchemeName}`), where `oisTitle` is the `title` field of the related OIS, and `securitySchemeName` is the name of the respective security scheme. These would be `myOisTitle` and `mySecurityScheme` in the example below. `securitySchemeValue` is the value used for the authentication with the security scheme (e.g., the API key).
+Each entry in `apiCredentials` maps to a security scheme defined in an OIS (`ois[n].components.securitySchemes.{securitySchemeName}` and `ois[n].security`), where `oisTitle` is the `title` field of the related OIS, and `securitySchemeName` is the name of the respective security scheme. These would be `myOisTitle` and `mySecurityScheme` in the example below. `securitySchemeValue` is the value used for the authentication with the security scheme (e.g., the API key).
 
 Use of apiCredentials is not required, leave its array empty.
 
@@ -217,6 +217,7 @@ Use of apiCredentials is not required, leave its array empty.
 ]
 
 // From the OIS object apiCredentials is referencing
+// using the oisTitle/securitySchemeName pair.
 {
   "title": "myOisTitle",
   ...,
@@ -229,6 +230,9 @@ Use of apiCredentials is not required, leave its array empty.
       }
     }
   },
+  "security":{
+    "mySecurityScheme": []
+  }
   ...
 }
 ```

--- a/docs/airnode/v1.0/grp-providers/tutorial/config-json.md
+++ b/docs/airnode/v1.0/grp-providers/tutorial/config-json.md
@@ -99,7 +99,8 @@ The config.json file contents shown below is for the [Quick Deploy](./) demo.
         },
         "components": {
           "securitySchemes": {}
-        }
+        },
+        "security":{}
       },
       "endpoints": [
         {

--- a/docs/airnode/v1.0/reference/deployment-files/config-json.md
+++ b/docs/airnode/v1.0/reference/deployment-files/config-json.md
@@ -205,7 +205,9 @@ A list of OIS objects. Since each OIS specifies the integration of an API to an 
 
 ## apiCredentials
 
-Each entry in `apiCredentials` maps to a security scheme defined in an OIS (`ois[n].components.securitySchemes.{securitySchemeName}`), where `oisTitle` is the `title` field of the related OIS, and `securitySchemeName` is the name of the respective security scheme. These would be `myOisTitle` and `mySecurityScheme` in the example below. `securitySchemeValue` is the value used for the authentication with the security scheme (e.g., the API key).
+Each entry in `apiCredentials` maps to a security scheme defined in an OIS (`ois[n].components.securitySchemes.{securitySchemeName}`), where `oisTitle` is the `title` field of the related OIS, and `securitySchemeName` is the name of the respective security scheme. These would be `myOisTitle` and `mySecurityScheme` in the example below. `securitySchemeValue` is the value used for the authentication with the security scheme (e.g., the API key) which would be in `secrets.env` in the example below.
+
+The `security` field in the OIS object must be included and hold the names of all security schemes the API operation
 
 Use of apiCredentials is not required, leave its array empty.
 
@@ -214,25 +216,28 @@ Use of apiCredentials is not required, leave its array empty.
 [
   {
     "oisTitle": "myOisTitle",
-    "securitySchemeName": "",
+    "securitySchemeName": "mySecurityScheme",
     "securitySchemeValue": "${SS_MY_API_KEY}"
   }
 ]
 
-// components object in OIS object
+// components and security field in OIS object
 {
-  "title": "myOisTitle",
-  ...,
-  "components": {
-    "securitySchemes": {
-      "mySecurityScheme": {
-        "in": "header",
-        "type": "apiKey",
-        "name": "X-api-key"
-      }
+"title": "myOisTitle",
+...,
+"components": {
+  "securitySchemes": {
+    "mySecurityScheme": {
+      "in": "header",
+      "type": "apiKey",
+      "name": "X-api-key"
     }
-  },
-  ...
+  }
+},
+"security": {
+  "mySecurityScheme" []
+}
+...
 }
 ```
 

--- a/docs/airnode/v1.0/reference/examples/config-json.md
+++ b/docs/airnode/v1.0/reference/examples/config-json.md
@@ -92,6 +92,9 @@ title: config.json
               "name": "X_access_key"
             }
           }
+        },
+        "security": {
+          "Currency Converter Security Scheme": []
         }
       },
       "endpoints": [

--- a/docs/airnode/v1.0/reference/specifications/ois.md
+++ b/docs/airnode/v1.0/reference/specifications/ois.md
@@ -7,26 +7,33 @@ title: Oracle Integration Specifications (OIS) 1.0.0
 <TocHeader /> <TOC class="table-of-contents" :include-level="[2,3]" />
 
 The Oracle Integration Specification (OIS) is based on [Open API specification
-(OAS)](https://swagger.io/specification/), but there are some differences, so be sure to read our documentation when
-working on your OIS file.
+(OAS)](https://swagger.io/specification/), but there are some differences, so be sure to read our documentation when working on your OIS file.
 
-*See our article, [Setting Oracle Integration
-Standards](https://medium.com/api3/setting-oracle-integration-standards-ac9104c38f9e) for an overview of OIS.*
+::: warning OAS
+It is not recommended to refer to OAS for help while creating your OIS object. OIS only borrows formatting practices from OAS. Everything needed to create an OIS object is in these docs. 
+:::
 
-*Fields denoted by \* are for documentation purposes and not used by the oracle node.*
+See the article, [Setting Oracle Integration
+Standards](https://medium.com/api3/setting-oracle-integration-standards-ac9104c38f9e) for an overview of OIS.
 
-*The [OAS](https://swagger.io/specification/) equivalents given are used to automatically populate OIS fields. These
-prepopulated fields are expected to be reviewed and customized by the integrating party.*
-
-*All URLs are absolute (i.e., [relative
+- Fields denoted by \* are for documentation purposes and not used by the oracle node. 
+- The [OAS](https://swagger.io/specification/) equivalents are given as reference to assist in the populating of OIS fields. The OIS fields should be reviewed and customized by the integrating party.
+- All URLs are absolute (i.e., [relative
 URLs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#relative-references-in-urls) are not
-supported).*
+supported).
+
+
+## OIS Object Summary 
+
+An OIS has five fields.
 
 - [`oisFormat`](ois.md#_1-oisformat)
 - [`title`](ois.md#_2-title)
 - [`version`](ois.md#_3-version)
 - [`apiSpecifications`](ois.md#_4-apispecifications)
 - [`endpoints`](ois.md#_5-endpoints)
+
+`apiSpecifications` describe the API's operations which are mapped to the `endpoints` that Airnode exposes on-chain.
 
 ```json
 {
@@ -62,8 +69,9 @@ OAS equivalent: `info.title`
 (Required) An object specifying the API with the following fields:
 
 - [`servers`](ois.md#_4-1-servers)
-- [`components`](ois.md#_4-2-components)
-- [`paths`](ois.md#_4-3-paths)
+- [`paths`](ois.md#_4-2-paths)
+- [`components`](ois.md#_4-3-components)
+- [`security`](ois.md#_4-4-security)
 
 ```json
 // apiSpecifications
@@ -73,15 +81,6 @@ OAS equivalent: `info.title`
       "url": "https://myapi.com/api/v1"
     }
   ],
-  "components": {
-    "securitySchemes": {
-      "mySecurityScheme1": {
-        "type": "apiKey",
-        "name": "X-MY-API-KEY",
-        "in": "query"
-      }
-    }
-  },
   "paths": {
     "/myPath": {
       "get": {
@@ -93,6 +92,18 @@ OAS equivalent: `info.title`
         ]
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "mySecurityScheme1": {
+        "type": "apiKey",
+        "name": "X-MY-API-KEY",
+        "in": "query"
+      }
+    }
+  },
+  "security": {
+    "mySecurityScheme1": []
   }
 }
 ```
@@ -104,66 +115,26 @@ array. Applies to all operations.
 
 OAS equivalent: `servers.0` (raise warning during conversion if `servers` has multiple elements)
 
-### 4.2. `components`
-
-(Required) An object where security schemes can be found under `securitySchemes.{securitySchemeName}` with the following
-elements:
-
-- [`type`](ois.md#_4-2-1-type)
-- [`name`](ois.md#_4-2-2-name)
-- [`in`](ois.md#_4-2-3-in)
-- [`scheme`](ois.md#_4-2-4-scheme)
-
-#### 4.2.1. `type`
-
-(Required) The type of the security scheme.
-
-Allowed values: `apiKey`, `http`
-
-OAS equivalent: `components.securitySchemes.{securitySchemeName}.type`
-
-#### 4.2.2. `name`
-
-(Required if `type` is apiKey) The name of the security scheme variable.
-
-OAS equivalent: `components.securitySchemes.{securitySchemeName}.name`
-
-#### 4.2.3. `in`
-
-(Required) The location of the security scheme variable.
-
-Allowed values: `query`, `header`, `cookie`
-
-OAS equivalent: `components.securitySchemes.{securitySchemeName}.in`
-
-#### 4.2.4. `scheme`
-
-(Required if `type` is http) The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
-
-Allowed values: <!--The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml). The OIS object supports--> `basic` and `bearer`.
-
-OAS equivalent: `components.securitySchemes.{securitySchemeName}.scheme`
-
-### 4.3. `paths`
+### 4.2. `paths`
 
 (Required) An object where operations can be found under `{path}.{method}` with the following elements:
 
 - [`parameters`](#431-parameters)
 
-#### 4.3.1. `parameters`
+#### 4.2.1. `parameters`
 
 (Required) A list of operation parameters, each with the following fields:
 
-- [`name`](ois.md#_4-3-1-1-name)
-- [`in`](ois.md#_4-3-1-2-in)
+- [`name`](ois.md#_4-2-1-1-name)
+- [`in`](ois.md#_4-2-1-2-in)
 
-##### 4.3.1.1. `name`
+##### 4.2.1.1. `name`
 
 (Required) The name of the parameter.
 
 OAS equivalent: `paths.{path}.{method}.parameters.{#}.name`
 
-##### 4.3.1.2. `in`
+##### 4.2.1.2. `in`
 
 (Required) The location of the parameter.
 
@@ -173,6 +144,63 @@ OAS equivalent: `paths.{path}.{method}.parameters.{#}.in`
 
 When integrating a POST method, define the body parameters with `in: query`. Airnode will convert all `query` types into
 the `requestBody`. Note that only the non-nested application/json content-type is supported.
+
+
+### 4.3. `components`
+
+(Required) An object where security schemes can be found under `securitySchemes.{securitySchemeName}` with the following
+elements:
+
+- [`type`](ois.md#_4-3-1-type)
+- [`name`](ois.md#_4-3-2-name)
+- [`in`](ois.md#_4-3-3-in)
+- [`scheme`](ois.md#_4-3-4-scheme)
+
+#### 4.3.1. `type`
+
+(Required) The type of the security scheme.
+
+Allowed values: `apiKey`, `http`
+
+OAS equivalent: `components.securitySchemes.{securitySchemeName}.type`
+
+#### 4.3.2. `name`
+
+(Only if `type` is apiKey) The name of the security scheme variable.
+
+OAS equivalent: `components.securitySchemes.{securitySchemeName}.name`
+
+#### 4.3.3. `in`
+
+(Only if type is apiKey) The location of the security scheme variable.
+
+Allowed values: `query`, `header`, `cookie`
+
+OAS equivalent: `components.securitySchemes.{securitySchemeName}.in`
+
+#### 4.3.4. `scheme`
+
+(Only if `type` is http) The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
+
+Allowed values: <!--The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml). The OIS object supports--> `basic` and `bearer`.
+
+OAS equivalent: `components.securitySchemes.{securitySchemeName}.scheme`
+
+### 4.4. `security`
+
+(Required) An object containing all security schemes that need to be used to access the API. Applies to all operations. Unlike in OAS, security cannot be a list. Each security scheme maps to an empty list as:
+
+```json
+"security": {
+  "mySecurityScheme1": []
+}
+```
+
+OAS equivalent: `security`, or `security.0` if security is a list.
+
+::: warning Please note:
+Currently Airnode reads the security schemes from `component.securitySchemes` and not `security`. Using the `security` field now provides for a smooth transition to future releases of Airnode with regards to security scheme implementation. This will allow assigning of security schemes to individual API operations. Currently security schemes are assign to the entire API.
+:::
 
 ## 5. `endpoints`
 

--- a/docs/airnode/v1.0/reference/templates/config-json.md
+++ b/docs/airnode/v1.0/reference/templates/config-json.md
@@ -99,9 +99,13 @@ See [config.json](../deployment-files/config-json.md) as a reference while build
             "<FILL_SECURITY_SCHEME_NAME>": {
               "in": "<FILL_*>",
               "type": "<FILL_*>",
-              "name": "<FILL_*>"
+              "name": "<FILL_*>",
+              "scheme":"<FILL_*>"
             }
           }
+        },
+        "security":{
+          "<FILL_SECURITY_SCHEME_NAME>": []
         }
       },
       "endpoints": [

--- a/docs/airnode/v1.0/reference/templates/ois-json.md
+++ b/docs/airnode/v1.0/reference/templates/ois-json.md
@@ -49,6 +49,9 @@ repository](https://github.com/api3dao/airnode/tree/master/packages/examples/int
           "name": "<FILL_*>"
         }
       }
+    },
+    "security":{
+      "<FILL_SECURITY_SCHEME_NAME>": []
     }
   },
   "endpoints": [


### PR DESCRIPTION
These changes add back the `ois[n].apiSpecifications.security` field. Also added warning not to bother with OAS help, that OIS borrows formatting practices from OAS.