### PR TITLE
Reduce CI runs by restricting push runs to main

### DIFF
--- a/.github/workflows/check-links-imgs.yaml
+++ b/.github/workflows/check-links-imgs.yaml
@@ -2,6 +2,8 @@ name: Check links and images
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently the CI is running twice for each PR commit because the commit qualifies under `push:` and `pull_request:`. This update restricts push runs to only main and therefore should help reduce the 429 Too Many Requests errors.