### PR TITLE
Add scrollbar to stop navbar shift on short pages

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -40,6 +40,11 @@
   border-left:solid #7963B2 5px !important;
 }
 
+/* Add permanent scrollbar to prevent top navigation bar shift on short pages */
+html{
+  overflow-y: scroll;
+}
+
 h1{
   color:#301934 !important;
 }


### PR DESCRIPTION
This PR adds a permanent scrollbar so navigating between pages with less than and more than a screenful of content does not shift the top navigation bar. Tested in Chrome, Brave, Firefox, Edge.

Short page without scrollbar, orange line for reference:
![image](https://user-images.githubusercontent.com/13989647/138605484-698c0ce4-c22c-4273-bce0-f05c3cbdafa4.png)


Longer page with scrollbar, orange line in same place shows how the navbar shifts because of the scrollbar:
![image](https://user-images.githubusercontent.com/13989647/138605493-f4054596-1586-4b9c-ac11-6378bcc0b54d.png)

