### PR TITLE
Remove fixed table of contents scrollbar

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -210,7 +210,6 @@ div.dropdown-wrapper, ul.nav-dropdown, li.dropdown-item a.nav-link.router-link-e
     border-right:1px lightgrey solid;
     /* http://jsfiddle.net/RyanBrackett/b44Zn/ */
     overflow-x: hidden; /* Hide horizontal scrollbar */
-    overflow-y: scroll; /* Add vertical scrollbar */
     -webkit-overflow-scrolling: touch;
     height: 75%;
 }


### PR DESCRIPTION
This is to improve aesthetics. If the page shrinks vertically to less than the TOC height, a scrollbar will still appear as expected (without shifting text contents). Tested in Chrome, Firefox Edge, Safari.