### PR TITLE
Cache yarn dependencies in check-format workflow

### DIFF
--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.17.1'
+          cache: 'yarn'
       - name: Install Dependencies
         run: yarn install
       - name: Check formatting


### PR DESCRIPTION
Speeds up install time. See:
https://github.com/actions/setup-node#caching-packages-dependencies
and
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies