### PR TITLE
Use <a> tags for pdf viewing to local pdf file

### DIFF
--- a/docs/airnode/v0.2/README.md
+++ b/docs/airnode/v0.2/README.md
@@ -32,9 +32,9 @@ implementation.
 
 ::: tip
 
-Learn more about Airnode experience Read Section 4 of the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf).
-_Airnode: A Node Designed for First-Party Oracles_
+Learn more about Airnode experience. Read Section 4 of the
+<a href="/api3-whitepaper-v1.0.1.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+Whitepaper</a>, _Airnode: A Node Designed for First-Party Oracles_
 
 :::
 

--- a/docs/airnode/v0.3/README.md
+++ b/docs/airnode/v0.3/README.md
@@ -32,9 +32,9 @@ implementation.
 
 ::: tip
 
-Learn more about Airnode experience Read Section 4 of the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf).
-_Airnode: A Node Designed for First-Party Oracles_
+Learn more about the Airnode experience. Read Section 4 of the
+<a href="/api3-whitepaper-v1.0.1.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+Whitepaper</a>, _Airnode: A Node Designed for First-Party Oracles_
 
 :::
 

--- a/docs/api3/README.md
+++ b/docs/api3/README.md
@@ -34,7 +34,8 @@ problem, **API3** aims to provide a much more optimal solution.
 ::: tip API3 Whitepaper (pdf)
 
 For a detailed discussion of the API3 project, read the
-<a href="/api3-whitepaper-v1.0.1.pdf" target="api3-docs">API3 Whitepaper</a>.
+<a href="/api3-whitepaper-v1.0.1.pdf" target="_api3-whitepaper">API3
+Whitepaper</a>.
 
 :::
 
@@ -56,8 +57,8 @@ implementation.
 ::: tip
 
 Learn more about Airnode Read Section 4 of the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf)
-to learn more. _Airnode: A Node Designed for First-Party Oracles_
+<a href="/api3-whitepaper-v1.0.1.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+Whitepaper</a> _Airnode: A Node Designed for First-Party Oracles_
 
 :::
 
@@ -77,7 +78,8 @@ learn more.
 ::: tab The Whitepaper
 
 **Abstract from the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf)</a>**
+<a href="/api3-whitepaper-v1.0.1.pdf" target="_api3-whitepaper">API3
+Whitepaper</a>**
 
 With decentralized applications beginning to provide meaningful services in
 areas such as decentralized finance, there is an increasing need for these

--- a/docs/api3/introduction/contributing.md
+++ b/docs/api3/introduction/contributing.md
@@ -24,8 +24,8 @@ sure to ask any questions you have on
   know about superficially.
 
 - To get a general grasp of the project, read the
-  [API3 whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf)
-  and our [blog posts](./symlink-blog-posts.md) on Medium.
+  <a href="/api3-whitepaper-v1.0.1.pdf" target="_api3-whitepaper">API3
+  Whitepaper</a> and our [blog posts](./symlink-blog-posts.md) on Medium.
 
 - Read the entirety of these docs. Take notes and cross-reference, but do not
   expect to understand everything. Feel free to ask questions.

--- a/docs/api3/introduction/dapis.md
+++ b/docs/api3/introduction/dapis.md
@@ -22,8 +22,8 @@ same solution can be reached through a more useful lens.
 Decentralized applications cannot access Web APIs, and oracle solutions aim to
 build decentralized interfaces to facilitate this. However, this approach
 results in an inferior solution and ecosystem (see the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf)
-for a detailed explanation).
+<a href="/api3-whitepaper-v1.0.1.pdf" target="_api3-whitepaper">API3
+Whitepaper</a> for a detailed explanation).
 
 <p align="center">
   <img src="../assets/images/dapi.png" />

--- a/docs/api3/introduction/first-party-oracles.md
+++ b/docs/api3/introduction/first-party-oracles.md
@@ -39,6 +39,7 @@ _See our article,
 for a comparison of the two types of oracles._
 
 Third party oracles are both insecure and expensive (see the
-[API3 Whitepaper](https://github.com/api3dao/api3-whitepaper/blob/master/api3-whitepaper.pdf)
-for a detailed explanation). In contrast, first-party oracles are both secure
-and cost-efficient due to not having a middleman on the interface path.
+<a href="/api3-whitepaper-v1.0.1.pdf#Issues%20with%20Third-Party%20Oracles%20as%20Middlemen" target="_api3-whitepaper">API3
+Whitepaper</a> _Issues with Third-Party Oracles as Middlemen_ for a detailed
+explanation). In contrast, first-party oracles are both secure and
+cost-efficient due to not having a middleman on the interface path.

--- a/docs/dao-members/introduction/api3-dao.md
+++ b/docs/dao-members/introduction/api3-dao.md
@@ -54,8 +54,8 @@ based on expert opinion. As API3 operations expand, this governance hierarchy
 may demand additional layers in the form of subDAOs.
 
 To learn more about hierarchical team structures
-<a href="/api3-whitepaper-v1.0.1.pdf#AI3%20DAO" target="api3-docs">see Section
-5.3 of the API3 Whitepaper</a>.
+<a href="/api3-whitepaper-v1.0.1.pdf#API3%20DAO" target="_api3-whitepaper"> see
+Section 5.3 of the API3 Whitepaper</a>.
 
 ### subDAO
 

--- a/docs/dao-members/introduction/dao-pool.md
+++ b/docs/dao-members/introduction/dao-pool.md
@@ -70,7 +70,7 @@ them to govern in a way that minimizes **_security_** risks. "_Security_" refers
 to a "guarantee or reliability of dAPI service"
 
 Reference
-<a href="/api3-whitepaper-v1.0.1.pdf#API3 tokenomics" target="api3-docs">section
+<a href="/api3-whitepaper-v1.0.1.pdf#API3%20tokenomics" target="_api3-whitepaper">section
 5.6 _"API3 Tokenomics"_</a> of the API3 whitepaper.
 
 ### Staking
@@ -125,7 +125,7 @@ through the dispute resolution protocol, user damages will be covered from the
 pool's staked tokens.
 
 Reference
-<a href="/api3-whitepaper-v1.0.1.pdf#Collateral" target="api3-docs">section
+<a href="/api3-whitepaper-v1.0.1.pdf#Collateral" target="_api3-whitepaper">section
 5.6.2 _"Collateral"_</a> of the API3 whitepaper.
 
 ### Governance
@@ -345,7 +345,6 @@ To insure against potential system failures, the DAO pool can empower special
 `payOutClaim(address recipient, uint256 amount)` in the DAO pool contract, which
 transfers tokens from the DAO pool to the recipient. When this occurs, the total
 number of staked tokens goes down, and pool share value goes down in turn.
-
 Reference
-<a href="/api3-whitepaper-v1.0.1.pdf#Insurance process" target="api3-docs">section
+<a href="/api3-whitepaper-v1.0.1.pdf#Insurance process" target="_api3-whitepaper">section
 5.6 _"Insurance process"_</a> of the API3 whitepaper.


### PR DESCRIPTION
The whitepaper now uses a `<a>` tag which allows the attachment of an anchor to the src. Also moves the pdf top a targeted tab `target="_api3-whitepaper"`.