### PR TITLE
Use class for divider

### DIFF
--- a/docs/.vuepress/components/SubSites.vue
+++ b/docs/.vuepress/components/SubSites.vue
@@ -61,13 +61,7 @@ it is normal behavior to force the user to the lastest version of airnode.
         <div class="btnText">API3</div>
       </router-link>
     </div>
-    <div
-      style="
-        border-top: solid 2px lightgrey;
-        margin-top: -5px;
-        margin-bottom: -12px;
-      "
-    ></div>
+    <div class="divider"></div>
   </div>
 </template>
 
@@ -148,5 +142,11 @@ div.container {
   text-align: center;
   margin-top: 10px;
   margin-bottom: -20px;
+}
+
+.divider {
+  border-top: solid 2px lightgrey;
+  margin-top: -5px;
+  margin-bottom: -12px;
 }
 </style>


### PR DESCRIPTION
Either way, class or style, prettier might add a line break inside the value which causes the browser to ignore the class or style. Using a class is safer mostly of the length of its value.

```js
class="divider"
// OR
style="color:red;border:solid 3em gray;"

// COULD END UP
class="
     divider
"
// OR
style="
      color:red;border:solid 3em gray;
"
```

The browser does not like the line break after the first double quote