### PR TITLE
Redirects for airnode-deployer

### DIFF
--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -19,3 +19,6 @@
 /airnode/latest/reference/packages/airnode-abi.html /airnode/v0.2/reference/packages/airnode-abi.html
 /airnode/latest/reference/packages/validator.html /airnode/v0.3/reference/packages/validator.html
 /airnode/latest/reference/specifications/airnode-abi-specifications.html /airnode/v0.2/reference/specifications/airnode-abi-specifications.html
+/airnode/latest/reference/packages/deployer.html /airnode/v0.3/reference/packages/deployer.html
+/airnode/latest/grp-providers/docker/ /airnode/v0.3/grp-providers/docker/
+/airnode/latest/grp-providers/tutorial/ /airnode/v0.3/grp-providers/tutorial/


### PR DESCRIPTION
There are three links in the updated README for the airnode-deployer package. This update adds three redirects for them using the `/latest/` route.