### PR TITLE
Document maximum encoded response length check

### DIFF
--- a/docs/airnode/v0.3/concepts/request.md
+++ b/docs/airnode/v0.3/concepts/request.md
@@ -21,7 +21,7 @@ function of AirnodeRrp.sol.
 > 1.  <p class="diagram-line">The requester calls makeFullRequest() on the AirnodeRrp protocol contract.</p>
 > 2.  <p class="diagram-line">makeFullRequest() assigns a requestId to the request for tracking purposes, adds the requestId to storage, emits the request to the event logs and returns the requestId to the requester.</p>
 > 3.  <p class="diagram-line" style="color:gray;">Airnode, during its run cycle, picks the request from the event logs.</p>
-> 4.  <p class="diagram-line" style="color:blue;">Airnode gets data from the API.</p>
+> 4.  <p class="diagram-line" style="color:blue;">Airnode gets data from the API and encodes it. The encoded response must have length at most 1024 bytes. (This is negligible in practice, since large responses are costly to store)</p>
 > 5.  <p class="diagram-line" style="color:green;">Airnode sends the response to fulFill() in AirnodeRrp which in turn removes the pending requestId from storage and forwards the response to myFulFill(). The requestId is included as part of the response.</p>
 
 Learn more on how to [Call an Airnode](../grp-developers/call-an-airnode.md).

--- a/docs/airnode/v0.3/grp-developers/call-an-airnode.md
+++ b/docs/airnode/v0.3/grp-developers/call-an-airnode.md
@@ -204,8 +204,8 @@ section.
 
 ## Step #3: Capture the Response
 
-As soon as the Airnode gets a request it will gather the data and start an
-on-chain transaction responding to the request. The Airnode calls the
+As soon as the Airnode gets a request it will gather the data, encode it and
+start an on-chain transaction responding to the request. The Airnode calls the
 AirnodeRrp.sol contract function `fulfill()` which in turn will call the
 requester, in this case, at `airnodeCallback`. Recall the request supplied the
 request contract address and the desired callback function which the


### PR DESCRIPTION
I've only mentioned it in the `request` document and this check doesn't mean much in practice.
As Burak mentioned in the jira issue, saving 1024 bytes string in storage would cost 640K gas and:
1) 640K gas is as of now 1132.112 Ethereum (https://walletinvestor.com/converter/gas/ethereum/640000)
2) 1132 ETH is 5,137,525 USD (https://coinmarketcap.com/converter/eth/usd/)

So we don't need to make a big deal of this check - it's mostly to secure the Airnode from being spammed by large requests.