### PR TITLE
The guide no longer treats GCP as a second class citizen.

### DIFF
--- a/docs/airnode/v0.3/grp-providers/guides/build-an-airnode/README.md
+++ b/docs/airnode/v0.3/grp-providers/guides/build-an-airnode/README.md
@@ -10,9 +10,13 @@ title: Getting Started
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
 The Build an Airnode guide will discuss, in detail, how an Airnode is
-constructed. But first, see the [Quick Deploy](../../tutorial/README.md) demo to
-get a simple understanding of an Airnode deployment. The demo has pre-configured
-files for a typical deployment.
+constructed. But first, see the [Quick Deploy](../../tutorial/README.md) demos
+to get a simple understanding of an Airnode deployment. The demos
+[Quick Deploy AWS](../../tutorial/quick-deploy-aws/) and
+[Quick Deploy GCP](../../tutorial/quick-deploy-gcp/) each have pre-configured
+downloadable project folders with files for a typical deployment. This guide
+primarily focuses on a deployment to AWS but describes changes that are needed
+for GCP deployments when encountered.
 
 ## Project Folder
 
@@ -22,19 +26,24 @@ into the locations show below.
 
 ```
 my-airnode
-├── aws.env
+├── aws.env      <- Only used for AWS deployments.
 ├── config
 │   ├── config.json
 │   └── secrets.env
 └── output
 ```
 
-Within this project, build out the configuration files and run the deployment.
+This guide will explain the content of the configuration files and run the
+deployment within this project folder. Use the files in the
+[Templates](../../../reference/templates/config-json.md) section of the docs to
+get a jump start if you are new to Airnode. Also consider the
+[Quick Deploy Demos](../../tutorial/) if you are new to Airnode before using
+this guide.
 
 ## Configuration
 
-The main focus of creating an Airnode is the preparation of three files that
-both define and support its creation.
+The main focus while creating an Airnode is the preparation of three files (two
+for GCP) that both define and support its creation.
 
 - `config.json`: Defines the Airnode and its behavior.
 - `secrets.env`: Hold secrets referenced by `config.json` using interpolation.
@@ -45,14 +54,15 @@ both define and support its creation.
 
 Last is the deployment. There are two ways to run the Airnode. The most popular
 is with a cloud provider like AWS or GCP. You would use the Docker
-[deployer image](../docker/../../docker/deployer-image.md) for this type of
-deployment. This guide (Build an Airnode) will use the deployer image.
+[Airnode Deployer Image](../docker/../../docker/deployer-image.md) for this type
+of deployment. This guide will use the deployer image.
 
-The second method is to run a containerized Airnode on a hosted internally or
-with a cloud provider service (e.g. AWS EC2 or Lightsail). You would use the
-Docker [client image](../../docker/client-image.md) for this type of deployment.
+The second method is to run a containerized Airnode hosted internally or with a
+cloud provider service (e.g. AWS EC2 or Lightsail). Use the Docker
+[Airnode Client Image](../../docker/client-image.md) for this type of
+deployment.
 
-Complete the following to build and deploy an Airnode.
+Complete the following sections for an in-depth understanding of Airnode.
 
 - [API Integration](api-integration.md)
 - [API Security](api-security.md)


### PR DESCRIPTION
However the reader does understand that the guide's focus is AWS to help with the flow and GCP is mentioned when that flow must be altered.