### PR TITLE
2021 12 14.1 corrections

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -35,7 +35,7 @@
 /************************************************/
 /* START Content */
 
-/** Change the left border color of the Vuepress tip quotebox to API3c Violet */
+/** Change the left border color of the VuePress tip quotebox to API3c Violet */
 .tip{
   border-left:solid #7963B2 5px !important;
 }

--- a/docs/airnode/v0.2/grp-developers/call-an-airnode.md
+++ b/docs/airnode/v0.2/grp-developers/call-an-airnode.md
@@ -160,12 +160,13 @@ parameters to pass on to `airnode.makeFullRequest`.
 
 - **parameters**: Specify the API parameters and any
   [reserved parameters](../reference/specifications/reserved-parameters.md),
-  these must be encoded. See [Airnode ABI specifications]() for how these are
-  encoded.
+  these must be encoded. See
+  [Airnode ABI specifications](../reference/specifications/airnode-abi-specifications.md)
+  for how these are encoded.
 
   In most cases the parameters will be encoded off-chain and passed to the
   requester which will only forward them. You can use the
-  [@api3/airnode-abi]()../reference/specifications/airnode-abi-specifications.html#api3-airnode-abi)
+  [@api3/airnode-abi](../reference/specifications/airnode-abi-specifications.md#api3-airnode-abi)
   package for the encoding and decoding. Take a look at the javascript snippet
   below.
 

--- a/docs/airnode/v0.3/grp-developers/call-an-airnode.md
+++ b/docs/airnode/v0.3/grp-developers/call-an-airnode.md
@@ -160,8 +160,9 @@ parameters to pass on to `airnode.makeFullRequest`.
 
 - **parameters**: Specify the API parameters and any
   [reserved parameters](../reference/specifications/reserved-parameters.md),
-  these must be encoded. See [Airnode ABI specifications]() for how these are
-  encoded.
+  these must be encoded. See
+  [Airnode ABI specifications](../reference/specifications/airnode-abi-specifications.md)
+  for how these are encoded.
 
   In most cases the parameters will be encoded off-chain and passed to the
   requester which will only forward them. You can use the

--- a/docs/airnode/v0.4/concepts/authorization.md
+++ b/docs/airnode/v0.4/concepts/authorization.md
@@ -14,7 +14,7 @@ two methods.
 
 - Authorizers - using authorizer contracts.
 - Relay security schemes - described in the build an airnode
-  [API Security](../grp-providers/guides/build-an-airnode/api-security.html#supported-security-schemes)
+  [API Security](../grp-providers/guides/build-an-airnode/api-security.md#supported-security-schemes)
   doc.
 
 <divider/>
@@ -159,9 +159,9 @@ wide-spread adoption.
 ### Are authorizers required?
 
 Authorizers are not required. An Airnode operator could use
-[relay security schemes](../grp-providers/guides/build-an-airnode/api-security.html#supported-security-schemes)
-to authorize API access (e.g. by [requester](./requester.html) address). And it
-is possible to use both authorizers and relay security schemes together.
+[relay security schemes](../grp-providers/guides/build-an-airnode/api-security.md#supported-security-schemes)
+to authorize API access (e.g. by [requester](./requester.md) address). And it is
+possible to use both authorizers and relay security schemes together.
 
 ### How are authorizers implemented?
 

--- a/docs/airnode/v0.4/grp-developers/call-an-airnode.md
+++ b/docs/airnode/v0.4/grp-developers/call-an-airnode.md
@@ -160,12 +160,13 @@ parameters to pass on to `airnode.makeFullRequest`.
 
 - **parameters**: Specify the API parameters and any
   [reserved parameters](../reference/specifications/reserved-parameters.md),
-  these must be encoded. See [Airnode ABI specifications]() for how these are
-  encoded.
+  these must be encoded. See
+  [Airnode ABI specifications](../reference/specifications/airnode-abi-specifications.md)
+  for how these are encoded.
 
   In most cases the parameters will be encoded off-chain and passed to the
   requester which will only forward them. You can use the
-  [@api3/airnode-abi](../reference/specifications/airnode-abi-specifications.html#api3-airnode-abi)
+  [@api3/airnode-abi](../reference/specifications/airnode-abi-specifications.md#api3-airnode-abi)
   package for the encoding and decoding. Take a look at the javascript snippet
   below.
 

--- a/docs/airnode/v0.4/grp-developers/requesters-sponsors.md
+++ b/docs/airnode/v0.4/grp-developers/requesters-sponsors.md
@@ -43,10 +43,10 @@ it.
 
 ::: tip sponsorAddress
 
-A [sponsorAddress](../concepts/sponsor.html#sponsoraddress) is a public address
-of an account from a mnemonic, usually the default account. Rather than the
-default account another account from the mnemonic can be used. The
-`sponsorAddress` is used to uniquely identify a sponsor.
+A [sponsorAddress](../concepts/sponsor.md#sponsoraddress) is a public address of
+an account from a mnemonic, usually the default account. Rather than the default
+account another account from the mnemonic can be used. The `sponsorAddress` is
+used to uniquely identify a sponsor.
 
 :::
 
@@ -141,7 +141,7 @@ on-chain. This command has transaction gas costs.
   alternate account to use from the mnemonic rather than the default account.
 
 Executing the command
-[sponsor-requester](../reference/packages/admin-cli.html#sponsor-requester) will
+[sponsor-requester](../reference/packages/admin-cli.md#sponsor-requester) will
 sponsor a requester and returns the requesterAddress and sponsorAddress.
 
 :::: tabs
@@ -184,7 +184,7 @@ the Airnode. Learn more about a
 [sponsorWallet](../concepts/sponsor.md#sponsorwallet).
 
 To derive a sponsorWallet for an Airnode execute the
-[derive-sponsor-wallet-address](../reference/packages/admin-cli.html#derive-sponsor-wallet-address)
+[derive-sponsor-wallet-address](../reference/packages/admin-cli.md#derive-sponsor-wallet-address)
 command using the parameters detailed in the list below. There are no
 transaction gas costs to do so.
 

--- a/docs/airnode/v0.4/grp-providers/docker/admin-cli-image.md
+++ b/docs/airnode/v0.4/grp-providers/docker/admin-cli-image.md
@@ -23,8 +23,8 @@ the
 in the Airnode repository.
 
 Additional information about the
-[admin CLI image](../../../v0.3/reference/packages/admin-cli.html#using-docker)
-is available in the admin CLI commands doc.
+[admin CLI image](../../../v0.3/reference/packages/admin-cli.md#using-docker) is
+available in the admin CLI commands doc.
 
 ## Usage
 

--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/api-integration.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/api-integration.md
@@ -76,7 +76,7 @@ make the necessary modifications to conform to the OIS format).
 If you already have an OAS file it may be possible to convert it to OIS. To
 assist in converting between various specifications e.g. from OAS to OIS, there
 is a `convert` command within the Airnode
-[validator](../../../reference/packages/validator.html#convertor) package.
+[validator](../../../reference/packages/validator.md#convertor) package.
 
 :::
 

--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/api-security.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/api-security.md
@@ -128,9 +128,9 @@ the encoded token for `bearer` auth.
 ### relayRequesterAddress
 
 The `relayRequesterAddress` security schema type instructs Airnode to forward
-the [requester](../../../concepts/requester.html) address to your API. The
-schema definition is similar to the [`apiKey`](./api-security.md#apikey),
-however the `type` must be `relayRequesterAddress`.
+the [requester](../../../concepts/requester.md) address to your API. The schema
+definition is similar to the [`apiKey`](./api-security.md#apikey), however the
+`type` must be `relayRequesterAddress`.
 
 Schema definition example:
 
@@ -274,10 +274,9 @@ in all OIS definitions. Each element of this array contains the following fields
   to interpolate it from `secrets.env`.
 
 If you want to base your API authentication on dynamic data, for example
-[requester](../../../concepts/requester.html) address, you can utilize the
-"relay" security schemes
-[described above](./api-security.md#relayrequesteraddress) which can forward
-this data to your API.
+[requester](../../../concepts/requester.md) address, you can utilize the "relay"
+security schemes [described above](./api-security.md#relayrequesteraddress)
+which can forward this data to your API.
 
 ::: warning Relay security schemes do not require a scheme value
 

--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -287,7 +287,7 @@ can have more than one OIS object. Fill these in accordingly.
 [<img :src="$withBase('/img/info8.png')" alt="info" class="infoIcon">](../../../reference/deployment-files/config-json.md#rrp-endpointid)
 Add an `endpointId` to the trigger which is the ID that a requester will use for
 on-chain requests to reference a specific trigger. Use the admin CLI command
-[derive-endpoint-id](../../../reference/packages/admin-cli.html#derive-endpoint-id)
+[derive-endpoint-id](../../../reference/packages/admin-cli.md#derive-endpoint-id)
 to derive endpoint IDs using the `oisTitle` and `endpointName`.
 
 ```bash

--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/http-gateway.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/http-gateway.md
@@ -143,7 +143,7 @@ The response format is a simple JSON object with the following fields:
 
 - `rawValue` - the API response
 - `values` - an array of values after they are
-  [extracted and converted](../../../reference/packages/adapter.html#conversion)
+  [extracted and converted](../../../reference/packages/adapter.md#conversion)
   to the target type
 - `encodedValue` - the encoded bytes value that is sent as payload in the
   response transaction on chain

--- a/docs/airnode/v0.4/reference/packages/adapter.md
+++ b/docs/airnode/v0.4/reference/packages/adapter.md
@@ -12,7 +12,7 @@ title: Adapter
 The
 [airnode-adapter](https://github.com/api3dao/airnode/tree/v0.3/packages/airnode-adapter)
 package has multiple responsibilities. It is used for building requests from an
-[Oracle Integration Specification (OIS)](../../grp-providers/guides/build-an-airnode/api-integration.html#ois-template),
+[Oracle Integration Specification (OIS)](../../grp-providers/guides/build-an-airnode/api-integration.md#ois-template),
 executing them, parsing the responses, but also converting and encoding them for
 on chain use.
 

--- a/docs/airnode/v0.4/reference/packages/validator.md
+++ b/docs/airnode/v0.4/reference/packages/validator.md
@@ -158,7 +158,7 @@ npx @api3/airnode-validator --template="config" --secrets="secrets.env" --specs=
 
 The following code example validates an `ois` field that has been placed in a
 file separate from its config.json file. The
-[ois field](../specifications/ois.html) contains the mapping between an API and
+[ois field](../specifications/ois.md) contains the mapping between an API and
 Airnode endpoints. _(interpolation with an env file is supported)_
 
 ```sh
@@ -169,7 +169,7 @@ npx @api3/airnode-validator --template="OIS" --specs="myProject/config/ois.json"
 
 The following code example validates an `ois.apiSpecifications` field that has
 been placed in a file separate from its config.json file. The
-[ois.apiSpecifications field](../specifications/ois.html#_4-apispecifications)
+[ois.apiSpecifications field](../specifications/ois.md#_4-apispecifications)
 defines/specifies the API Airnode will call. _(interpolation with an env file is
 supported)_
 
@@ -181,7 +181,7 @@ npx @api3/airnode-validator --template="endpoints" --specs="myProject/config/api
 
 The following code example validates an `ois.endpoints` field that has been
 placed in a file separate from its config.json file. The
-[ois.endpoints field](../specifications/ois.html#_5-endpoints) are Airnode
+[ois.endpoints field](../specifications/ois.md#_5-endpoints) are Airnode
 endpoints that map to the `ois.apiSpecifications` field in config.json.
 _(interpolation with an env file is supported)_
 

--- a/docs/airnode/v0.4/reference/specifications/reserved-parameters.md
+++ b/docs/airnode/v0.4/reference/specifications/reserved-parameters.md
@@ -267,5 +267,5 @@ Airnode will extract and convert each of the "split values" separately
 
 All of these values are then together encoded to single bytes value that can be
 sent on chain. You can use
-[testing gateway](../../grp-providers/guides/build-an-airnode/deploying-airnode.html#testing-with-http-gateway)
+[testing gateway](../../grp-providers/guides/build-an-airnode/deploying-airnode.md#testing-with-http-gateway)
 to inspect the raw API response, casting results and the final encoded value.

--- a/docs/dev/override-components.md
+++ b/docs/dev/override-components.md
@@ -70,7 +70,7 @@ been added to **Navbar.vue**.
 
 The override component Sidebar.vue is a replacement for the VuePress
 Sidebar.vue. The custom component
-[DocumentSets.vue](./custom-components.md#document-sets-vue) has been added to
+[DocumentSets.vue](./custom-components.md#documentsets-vue) has been added to
 **Sidebar.vue**.
 
 #### Changes


### PR DESCRIPTION
Minor corrections mostly for use of `.html` rather than `.md` for internal markdown links. 