### PR TITLE
AN460_Added back options chain fields missing since pre-alpha.

### DIFF
--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -89,7 +89,10 @@ Below is a simple chain array with a single chain provider.
       "infura_rinkeby": {
         "url": "${INFURA_RINKEBY_PROVIDER_URL}"
       }
-    ]
+    ],
+    "blockHistoryLimit": 300,
+    "minConfirmations": 0,
+    "ignoreBlockedRequestsAfterBlocks": 20
   }
 ],
 ```
@@ -134,20 +137,32 @@ The type of the chain. Only `evm` is supported at this time. See additional
 definition in the
 [reference section](../../../reference/deployment-files/config-json.md#type).
 
-<!-- This is on hold as there is an incomplete GitHub issue to implement these.
-https://github.com/api3dao/airnode/issues/41
+#### options
+
+[<img :src="$withBase('/img/info8.png')" alt="info" class="infoIcon">](../../../reference/deployment-files/config-json.md#options)
+An object that configures chain-related options.
+
+- txType: The transaction type to use.
+- priorityFee: An object that configures the EIP-1559 Priority Fee.
+- baseFeeMultiplier: Configures the EIP-1559 Base Fee to Maximum Fee Multiplier.
+
 #### blockHistoryLimit
 
-`blockHistoryLimit` (optional) - the number of blocks in the past that the Airnode deployment should search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
+[<img :src="$withBase('/img/info8.png')" alt="info" class="infoIcon">](../../../reference/deployment-files/config-json.md#blockhistorylimit)
+The number of blocks in the past that the Airnode deployment should search for
+requests. Defaults to `300` (roughly 1 hour for Ethereum).
 
 #### minConfirmations
 
-`minConfirmations` (optional) - the number of confirmations required for a request to be considered valid. Defaults to `0`.
+[<img :src="$withBase('/img/info8.png')" alt="info" class="infoIcon">](../../../reference/deployment-files/config-json.md#minconfirmations)
+The number of confirmations required for a request to be considered valid.
+Defaults to `0`.
 
 #### ignoreBlockedRequestsAfterBlocks
 
-`ignoreBlockedRequestsAfterBlocks` (optional) - the number of blocks that need to pass for the node to start ignoring blocked requests. Defaults to `20`.
--->
+[<img :src="$withBase('/img/info8.png')" alt="info" class="infoIcon">](../../../reference/deployment-files/config-json.md#ignoreblockedrequestsafterblocks)
+The number of blocks that need to pass for the node to start ignoring blocked
+requests. Defaults to `20`.
 
 ### nodeSettings
 

--- a/docs/airnode/v0.4/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.4/reference/deployment-files/config-json.md
@@ -65,7 +65,10 @@ respective parameters.
         "unit": "gwei"
       },
       "baseFeeMultiplier": "2"
-    }
+    },
+    "blockHistoryLimit": 300,
+    "minConfirmations": 0,
+    "ignoreBlockedRequestsAfterBlocks": 20
   },
   {
     "authorizers": [],
@@ -145,16 +148,22 @@ to`{"value": "3.12", "value": "gwei"}`)
 The resulting Maximum Fee will equal
 `(Base Fee * baseFeeMultiplier) + priorityFee`
 
-<!--
-- `blockHistoryLimit` (optional) - the number of blocks in the past that the Airnode deployment should search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
+### `blockHistoryLimit`
 
-- `minConfirmations` (optional) - the number of confirmations required for a request to be considered valid. Defaults to
-  `0`.
+(optional) - the number of blocks in the past that the Airnode deployment should
+search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
 
-- `ignoreBlockedRequestsAfterBlocks` (optional) - the number of blocks that need to pass for the node to start ignoring
-  blocked requests. Defaults to `20`. A request is blocked whenever the API call cannot be made. For example, endpoint
-  (specified by its id in the request) cannot be found in config.json.
--->
+### `minConfirmations`
+
+(optional) - the number of confirmations required for a request to be considered
+valid. Defaults to `0`.
+
+### `ignoreBlockedRequestsAfterBlocks`
+
+(optional) - the number of blocks that need to pass for the node to start
+ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
+API call cannot be made. For example, endpoint (specified by its id in the
+request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.4/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.4/reference/examples/config-cloud.json
@@ -19,7 +19,10 @@
           "unit": "gwei"
         },
         "baseFeeMultiplier": "2"
-      }
+      },
+      "blockHistoryLimit": 300,
+      "minConfirmations": 0,
+      "ignoreBlockedRequestsAfterBlocks": 20
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.4/reference/examples/config-local.json
+++ b/docs/airnode/v0.4/reference/examples/config-local.json
@@ -19,7 +19,10 @@
           "unit": "gwei"
         },
         "baseFeeMultiplier": "2"
-      }
+      },
+      "blockHistoryLimit": 300,
+      "minConfirmations": 0,
+      "ignoreBlockedRequestsAfterBlocks": 20
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.4/reference/templates/config-json.md
+++ b/docs/airnode/v0.4/reference/templates/config-json.md
@@ -43,7 +43,18 @@ building a config.json file.
           "url": "${CHAIN_PROVIDER_URL}" // In secrets.env
         }
       },
-      "type": "<FILL_*>"
+      "type": "<FILL_*>",
+      "options": {
+        "txType": "<FILL_*>",
+        "priorityFee": {
+          "value": "<FILL_*>",
+          "unit": "<FILL_*>"
+        },
+        "baseFeeMultiplier": "<FILL_*>"
+      },
+      "blockHistoryLimit": "<FILL_*>",
+      "minConfirmations": "<FILL_*>",
+      "ignoreBlockedRequestsAfterBlocks": "<FILL_*>"
     }
   ],
   "nodeSettings": {


### PR DESCRIPTION
These are not the `chains[n].options`. This is done only for v0.4 first to validate the changes are correct. They then will be added back to `v0.2` and `v0.3`.