### PR TITLE
Forget to set the icon in the code block for temp prod use.

### DIFF
--- a/docs/.vuepress/components/DocumentSets.vue
+++ b/docs/.vuepress/components/DocumentSets.vue
@@ -130,8 +130,8 @@ export default {
       if (!flag && path.indexOf('/beacon/v') > -1) {
         this.docSets.push({
           name: 'Beacons',
-          iconActive: '/img/Beacons-icon-black.png',
-          iconInactive: '/img/Beacons-icon-black.png',
+          iconActive: '/img/Beacons-active.png',
+          iconInactive: '/img/Beacons-default.png',
           path: latestBeaconVersion,
         });
       }


### PR DESCRIPTION
Becasue Beacons are not ready this code block adds teh Beacons doc set into the pick list if the reader enters the `/beacon/` route directly into the URL bar.