### PR TITLE
AN384 proposals

### DIFF
--- a/docs/dao-members/contract-architecture/README.md
+++ b/docs/dao-members/contract-architecture/README.md
@@ -20,8 +20,8 @@ for how to deploy a copy of the DAO.
 | DAO Pool         | `0x6dd655f10d4b9e242ae186d9050b68f725c76d76` |
 | Primary Voting   | `0xdb6c812e439ce5c740570578681ea7aadba5170b` |
 | Secondary Voting | `0x1c8058e72e4902b3431ef057e8d9a58a73f26372` |
-| Primary agent    | `0xd9f80bdb37e6bad114d747e60ce6d2aaf26704ae` |
-| Secondary agent  | `0x556ecbb0311d350491ba0ec7e019c354d7723ce0` |
+| Primary Agent    | `0xd9f80bdb37e6bad114d747e60ce6d2aaf26704ae` |
+| Secondary Agent  | `0x556ecbb0311d350491ba0ec7e019c354d7723ce0` |
 | Convenience      | `0x95087266018b9637aff3d76d4e0cad7e52c19636` |
 
 <!-- Add mainnet addresses to this list -->

--- a/docs/dao-members/contract-architecture/voting.md
+++ b/docs/dao-members/contract-architecture/voting.md
@@ -19,9 +19,8 @@ passes.
 
 The API3 DAO has installed two instances of its voting app, primary and
 secondary versions, along with two Aragon Agents that they control. The primary
-app commands a larger treasury and can update all DAO settings, while the
-secondary commands a much smaller treasury and can update some of the DAO
-settings.
+commands a larger treasury and can update all DAO settings, while the secondary
+commands a much smaller treasury and can update some of the DAO settings.
 
 See the
 [Api3Voting.sol](https://github.com/api3dao/api3-dao/tree/main/packages/dao/contracts)

--- a/docs/dao-members/dashboard/proposals.md
+++ b/docs/dao-members/dashboard/proposals.md
@@ -44,21 +44,21 @@ page displays proposals that have been executed or rejected.
 
 1. Navigate to the **Governance** page.
 
-> Here you can browse and create proposals, view the treasury, and delegate your
-> votes. **Active proposals** lists all proposals open for voting.
+   > Here you can browse and create proposals, view the treasury, and delegate
+   > your votes. **Active proposals** lists all proposals open for voting.
 
-> There are two types of proposals, primary and secondary. Primary proposals
-> require an absolute majority vote, while secondary proposals require a 15%
-> vote to pass. For each proposal in the list you can see the title, proposal
-> type, vote deadline, and vote status.
+   > There are two types of proposals, primary and secondary. Primary proposals
+   > require an absolute majority vote, while secondary proposals require a 15%
+   > vote to pass. For each proposal in the list you can see the title, proposal
+   > type, vote deadline, and vote status.
 
-> To view additional details click on the desired proposal. The detail view
-> shows your vote delegation status and a **Summary** section with the details
-> of the proposal.
+   > To view additional details click on the desired proposal. The detail view
+   > shows your vote delegation status and a **Summary** section with the
+   > details of the proposal.
 
 2. To view previous governance proposals, navigate to the **History** page.
 
-> Proposals in the history list have either been executed or rejected.
+   > Proposals in the history list have either been executed or rejected.
 
 :::
 
@@ -77,7 +77,7 @@ page displays proposals that have been executed or rejected.
 Proposals are an important part of DAO governance and can be used to fund DAO
 projects or ratify DAO level decisions like updating the stake target.
 
-Creating a proposal involves the following steps:
+Creating a proposal is a process:
 
 1. (Recommended) Promote your idea and gather feedback on the API3 forum using a
    [sentiment check post](https://forum.api3.org/t/sentiment-check-template/56).
@@ -92,12 +92,30 @@ Creating a proposal involves the following steps:
 4. Provide a link to this proposal in the official proposal forum thread to
    direct community members on where to vote.
 
-To create a new proposal using the DAO dashboard:
-
   <!--**Proposal Types**
 
   In general, a proposal type of _Primary_ has a larger treasury and more permissions but has more stringent voting settings than a _Secondary_ type. For a technical breakdown of the different permissions granted to the DAO's proposal types (and corresponding Agents) see this [README](https://github.com/api3dao/api3-dao/blob/develop/packages/dao/README.md#permissions).
   -->
+
+#### Important Tips
+
+::: tip Public Address and ENS Names
+
+For public addresses use the checksum version of the address where some
+alphabetical characters are capitalized. Copy your address to etherscan to get
+its checksum value. ENS names are allowed. See the
+[Using ENS Names](proposals.md#using-ens-names) section below.
+
+:::
+
+::: tip USDC Precision
+
+USDC uses 6 decimal places of precision as opposed to 18 that many other ERC20
+tokens use. Add 6 zeros after the amount you are asking for.
+
+:::
+
+To create a new proposal using the DAO dashboard:
 
 :::: tabs
 
@@ -107,12 +125,12 @@ To create a new proposal using the DAO dashboard:
 
 2. Select the **Proposal Type** on the proposal form.
 
-> Proposals can be submitted to either the _Primary_ or _Secondary_ voting
-> types. These two types have access to separate treasuries, have different
-> voting settings, and have different permissions to change contract settings.
-> For a technical breakdown of the different permissions granted to the DAO's
-> proposal types (and corresponding Agents) see this
-> [README](https://github.com/api3dao/api3-dao/blob/develop/packages/dao/README.md#permissions).
+   > Proposals can be submitted to either the _Primary_ or _Secondary_ voting
+   > types. These two types have access to separate treasuries, have different
+   > voting settings, and have different permissions to change contract
+   > settings. For a technical breakdown of the different permissions granted to
+   > the DAO's proposal types (and corresponding Agents) see this
+   > [README](https://github.com/api3dao/api3-dao/blob/develop/packages/dao/README.md#permissions).
 
 3. Enter a descriptive **Title**.
 
@@ -121,34 +139,44 @@ To create a new proposal using the DAO dashboard:
    > list.
 
 4. Enter a **Description** that details the proposal.
+
    > A description can be typed text but consider using a PDF hosted on IPFS.
    > See the [Using IPFS for Proposals](proposals.md#using-ipfs-for-proposals)
    > section below. Also consider adding a link back the forum where you posted
    > your proposal for discussion.
+
 5. Enter the **Target Contract** address.
+
    > This is the address of the contract to call. For example the commonly used
    > target contract for USDC is `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`.
+
 6. Enter the **Contract Target Signature**.
+
    > Defines the signature of the function to call within the target contract.
    > For the target contract USDC mentioned above use
    > `transfer(address,uint256)`. <span style="color:orange">Do not use any
    > spaces in the signature: leading, trailing or otherwise.</span>
+
 7. Enter an **ETH Value**.
+
    > You can use zero if the target function is not `payable`.
+
 8. Enter **Parameters** which are the arguments that will be used to satisfy the
    signature of the target contract function.
+
    > The arguments must be provided in JSON array format where the values are
    > stringified.
 
-> For public addresses use the checksum version of the address where some
-> alphabetical characters are capitalized. Copy your address to etherscan to get
-> its checksum value. ENS names are allowed. See the
-> [Using ENS Names](proposals.md#using-ens-names) section below.
+   ```json
+   ["0xF4EB52Cf9D31a...d1663d78ddDEE9", "500000000000"]
+   ```
 
-> When using USDC remember it has 6 decimals. Add 6 zeros after the amount you
-> are asking for.
+   In the example above 50,0000 USDC would be the transfer amount payable to
+   `0xF4EB52Cf9D31a...d1663d78ddDEE9` when calling the target contract
+   `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`.
 
 9. When you are ready, click the **Create** button at the bottom of the page.
+
    > The proposal is then added to the proposal list and can be voted on.
 
 :::
@@ -165,12 +193,12 @@ To create a new proposal using the DAO dashboard:
 
 A proposal is ready for execution if:
 
-1. the proposal hasn't already been executed, and
+1. The proposal hasn't already been executed, and
 2. greater than 50% of all voting power has voted "yes" on the proposal,
 
 OR
 
-1. the proposal hasn't already been executed, and
+1. The proposal hasn't already been executed, and
 2. the proposal's voting period has ended, and
 3. the total "yes" vote exceeds the "no" vote, and
 4. at least 50% (for Primary voting app proposals) or 15% (for Secondary voting

--- a/docs/dao-members/dashboard/proposals.md
+++ b/docs/dao-members/dashboard/proposals.md
@@ -171,7 +171,7 @@ To create a new proposal using the DAO dashboard:
    ["0xF4EB52Cf9D31a...d1663d78ddDEE9", "500000000000"]
    ```
 
-   In the example above 50,0000 USDC would be the transfer amount payable to
+   In the example above 500,000 USDC would be the transfer amount payable to
    `0xF4EB52Cf9D31a...d1663d78ddDEE9` when calling the target contract
    `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`.
 

--- a/docs/dao-members/dashboard/proposals.md
+++ b/docs/dao-members/dashboard/proposals.md
@@ -11,16 +11,16 @@ Staking tokens in the DAO pool gives you governance rights to create and vote on
 proposals.
 
 To create a proposal, you must not have created a proposal in the last seven
-days and you must hold at least 0.1% of the total pool shares. This required
-percentage, as well as other DAO parameters, can be adjusted by the DAO as
-described in
+days and you must hold at least 0.1% of the total staked tokens in the pool.
+This required percentage, as well as other DAO parameters, can be adjusted by
+the DAO as described in
 [Dashboard Attributes](../contract-architecture/dashboard-attributes.md). To
-view the percentage of pool shares for an address, visit the
+view the percentage of staked tokens in the pool for an address, visit the
 [DAO Tracker wallets page](https://enormous.cloud/dao/api3/tracker/wallets).
 
-You can vote on all proposals regardless of the percentage of pool shares you
-own. See [How to Vote](voting.md) for instructions. Alternatively, you can
-delegate your voting power to someone else. See the
+You can vote on all proposals regardless of the percentage of staked tokens in
+the pool you own. See [How to Vote](voting.md) for instructions. Alternatively,
+you can delegate your voting power to someone else. See the
 [delegation pitch section](https://forum.api3.org/c/delegation-pitch/7) of the
 API3 forum for posts by community members offering to act as delegates or to
 post your own delegate pitch.
@@ -168,12 +168,14 @@ To create a new proposal using the DAO dashboard:
    > stringified.
 
    ```json
-   ["0xF4EB52Cf9D31a...d1663d78ddDEE9", "500000000000"]
+   ["0xF4EB52Cf9D31a...d1663d78ddDEE9", "499999000000"]
    ```
 
-   In the example above 500,000 USDC would be the transfer amount payable to
-   `0xF4EB52Cf9D31a...d1663d78ddDEE9` when calling the target contract
-   `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`.
+   In the example above, the respective Agent (primary or secondary) would be
+   calling the USDC contract (`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`) to
+   transfer 499,999 USDC to `0xF4EB52Cf9D31a...d1663d78ddDEE9`. Note that since
+   `transfer(address,uint256)` transfers funds from the sender to the specified
+   address, the USDC is asked to be supplied from the Agent's balance.
 
 9. When you are ready, click the **Create** button at the bottom of the page.
 
@@ -191,6 +193,9 @@ To create a new proposal using the DAO dashboard:
 
 ## Proposal Execution
 
+<!-- The following is the older version of execution rules. This was not
+very accurate, see PR: AN384 proposals #516.
+
 A proposal is ready for execution if:
 
 1. The proposal hasn't already been executed, and
@@ -207,6 +212,19 @@ OR
 Once a proposal has satisfied either set of criteria, anyone can send a
 transaction executing it using the Execute button that appears on its details
 page, as shown below:
+-->
+
+A proposal is ready for execution if:
+
+1. The proposal hasn't already been executed, and
+2. the proposal's voting period has ended, and
+3. the total "yes" vote exceeds the "no" vote, and
+4. (for Secondary type proposals) at least 15% of all voting power has voted
+   "yes" on the proposal.
+
+Primary type proposals require 50% of all voting power to have voted "yes" on
+the proposal. Both primary and secondary type proposals execute immediately once
+50% of all voting power has voted "yes" on them.
 
 > <p align="left">
 >  <img src="../figures/dashboard/executable-proposal.png" width="400" />


### PR DESCRIPTION
So I have made some planned changes for clarity (AN-384) with regards to **Proposal Creation**. BUT since I had screwed up a previous release I do not intent to sink the boat again, at least not alone.

Please review this PR. Below are my points of concern. If the PR changed files view is confusing, please note I have uploaded a [PDF](https://github.com/api3dao/api3-docs/files/7799864/proposals-1.pdf) that shows how the doc would read as this point.

1. Added a **TIP** about USDC decimal precision of 6 places. From an older doc it said to add 6 zeros to the amount you want. So 500,000 would be 500000000000. Is this correct? What if someone wanted 500,000.19 is it 500000190000, not that the docs will speak to it but I am curious. Should this **TIP** be placed in `step #8`. I did not do so as to benefit those that might use the video rather than the text instructions. 

2. Please look at `step #8` in Proposal Creation. Is the json example correct for a value 500,000 USDC? I was concerned that the video shows a huge number and as such maybe I have the wrong understanding of how to write out USDC in the paramters. Please look at the [video](https://youtu.be/XO1iA3wSYMQ) parameters example. 

3. Also please note the paragraph under the json in `step #8`. Does it reflect the proposal call correctly as related to the contract address in `step #5`? 

4. Of course if you could read through the entire doc and express any other concerns or opportunities for improvement I would appreciate it.

[proposals-1.pdf](https://github.com/api3dao/api3-docs/files/7799864/proposals-1.pdf)





