### PR TITLE
20210107 linkvalidator ignore list

### DIFF
--- a/docs/airnode/v0.2/grp-providers/tutorial/README.md
+++ b/docs/airnode/v0.2/grp-providers/tutorial/README.md
@@ -13,7 +13,7 @@ This demo is a simple Airnode deployment, using a hands-on approach, to better
 understand the overall deployment process of the
 [deployer image](../../grp-providers/docker/deployer-image.md). It uses an API
 endpoint (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -14,7 +14,7 @@ understand the overall deployment process of the Airnode
 [deployer image](../../../grp-providers/docker/deployer-image.md) which deploys
 the off-chain component of Airnode (a.k.a., the node) to AWS. It uses an API
 endpoint (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-container/README.md
@@ -15,7 +15,7 @@ understand the overall deployment process of the Airnode
 the off-chain component of Airnode ([a.k.a., the node](../../../)) to a Docker
 container, in this case a locally run Docker container. It uses an API endpoint
 (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -14,7 +14,7 @@ understand the overall deployment process of the Airnode
 [deployer image](../../../grp-providers/docker/deployer-image.md) which deploys
 the off-chain component of Airnode (a.k.a., the node) to GCP. It uses an API
 endpoint (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -14,7 +14,7 @@ understand the overall deployment process of the Airnode
 [deployer image](../../../grp-providers/docker/deployer-image.md) which deploys
 the off-chain component of Airnode (a.k.a., the node) to AWS. It uses an API
 endpoint (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-container/README.md
@@ -15,7 +15,7 @@ understand the overall deployment process of the Airnode
 the off-chain component of Airnode ([a.k.a., the node](../../../)) to a Docker
 container, in this case a locally run Docker container. It uses an API endpoint
 (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -14,7 +14,7 @@ understand the overall deployment process of the Airnode
 [deployer image](../../../grp-providers/docker/deployer-image.md) which deploys
 the off-chain component of Airnode (a.k.a., the node) to GCP. It uses an API
 endpoint (`GET /coins/{id}`) from
-[CoinGecko](https://www.coingecko.com/en/api/documentation?) which returns the
+[CoinGecko](https://www.coingecko.com/en/api/documentation) which returns the
 current value of a coin. This demo does not detail the overall configuration of
 an Airnode, it is just a quick start.
 

--- a/docs/dao-members/README.md
+++ b/docs/dao-members/README.md
@@ -17,7 +17,7 @@ following topics are covered:
 
 ::: tip DAO Dashboard
 
-Access the [DAO Dashboard](https://api3.eth.link/) on **Mainnet**.
+Access the [DAO Dashboard](https://api3.eth.link/#/) on **Mainnet**.
 
 :::
 

--- a/docs/dao-members/dashboard/README.md
+++ b/docs/dao-members/dashboard/README.md
@@ -22,7 +22,7 @@ The DAO dashboard focuses on your interaction with the DAO:
 
 - Access the [DAO Dashboard](https://api3.eth.link/) on **Mainnet**.
 
-- Access the [Stage DAO Dashboard](https://staging.api3.eth.link/) on Rinkeby.
+- Access the [Stage DAO Dashboard](https://staging.api3.eth.link/#/) on Rinkeby.
   This is a staging area for beta and other testing but may not be available at
   certain times.
 

--- a/libs/link-validator.js
+++ b/libs/link-validator.js
@@ -8,7 +8,6 @@ var file = require('file');
 var colors = require('colors');
 const oust = require('oust');
 const axios = require('axios');
-const { getSystemErrorMap } = require('util');
 //const { versions } = require('process');
 
 /**
@@ -58,6 +57,15 @@ function tempCB(dirPath, dirs, files) {
 
 async function testLink(url, filePath) {
   try {
+    // TODO: This needs to moved to an ignore file
+    let ignore = [
+      'https://staging.api3.eth.link/#/',
+      'https://www.coingecko.com/en/api/documentation',
+    ];
+    if (ignore.includes(url)) {
+      return;
+    }
+
     axios.defaults.timeout = 10000;
     const response = await axios.get(url);
 


### PR DESCRIPTION
There are a view links to external sources that fail mostly due to timeouts and a 503 because they think it is a DOS attack. The ignore list stop the validation of these. There is a TODO: to make the array a file when there is more time.