### PR TITLE
20220128 jobs badge

### DIFF
--- a/docs/.vuepress/components/Navbar.vue
+++ b/docs/.vuepress/components/Navbar.vue
@@ -54,7 +54,7 @@
 
       <!-- Added: wkande: Job posting icon. 
       -->
-      <api3-JobsIcon />
+      <api3-JobsIcon v-show="!isLandingPage" />
 
       <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
       <!-- 

--- a/docs/.vuepress/components/Navbar.vue
+++ b/docs/.vuepress/components/Navbar.vue
@@ -52,18 +52,9 @@
       -->
       <Versions />
 
-      <!-- Added: wkande: Job posting icon. -->
-      <RouterLink to="/api3/introduction/work" class="home-link"
-        ><img
-          src="/img/work.png"
-          style="
-            width: 28px;
-            height: 28px;
-            padding-top: 4px;
-            margin-right: 10px;
-          "
-        />
-      </RouterLink>
+      <!-- Added: wkande: Job posting icon. 
+      -->
+      <api3-JobsIcon />
 
       <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
       <!-- 
@@ -97,7 +88,6 @@ export default {
     SearchBox,
     AlgoliaSearchBox,
   },
-
   data() {
     return {
       linksWrapMaxWidth: null,
@@ -105,14 +95,12 @@ export default {
       isLandingPage: false,
     };
   },
-
   computed: {
     algolia() {
       return (
         this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
       );
     },
-
     isAlgoliaSearch() {
       return this.algolia && this.algolia.apiKey && this.algolia.indexName;
     },

--- a/docs/.vuepress/components/Versions.vue
+++ b/docs/.vuepress/components/Versions.vue
@@ -89,7 +89,7 @@ button.nav-site-btn {
   border: solid 0px black;
   font-weight: bold;
   font-size: medium;
-  margin-right: 27px;
+  margin-right: 18px;
   cursor: pointer;
 }
 </style>

--- a/docs/.vuepress/components/VersionsModal.vue
+++ b/docs/.vuepress/components/VersionsModal.vue
@@ -57,7 +57,7 @@ export default {
   border-radius: 6px;
   color: gray;
   position: absolute;
-  top: 129px;
+  top: 139px;
   left: 93px;
   transform: translate(-50%, -50%);
   width: 100px;

--- a/docs/.vuepress/components/api3/JobsIcon.vue
+++ b/docs/.vuepress/components/api3/JobsIcon.vue
@@ -58,6 +58,6 @@ export default {
     width: 28px;
     height: 28px;
     padding-top: 4px;
-    margin-right: 10px
+    margin-right: 18px
 }
 </style>

--- a/docs/.vuepress/components/api3/JobsIcon.vue
+++ b/docs/.vuepress/components/api3/JobsIcon.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <RouterLink to="/api3/introduction/work" class="home-link"
+      ><span v-if="showBadge === true" class="jobsBadge">✅</span>
+      <img src="/img/work.png" class="jobsIcon" />
+    </RouterLink>
+  </div>
+</template>
+
+<script>
+import { jobPageRevision } from '../../config.js';
+
+export default {
+  name: 'JobsIcon',
+  data() {
+    return {
+      jobPageRevision: jobPageRevision,
+      showBadge: false,
+    };
+  },
+  mounted() {
+    this.$nextTick(function () {
+      this.showBadge =
+        this.jobPageRevision ===
+        parseInt(localStorage.getItem('jobPageRevision'))
+          ? false
+          : true;
+    });
+  },
+  watch: {
+    $route(event) {
+      if (event.path.indexOf('/api3/introduction/work.') > -1) {
+        localStorage.setItem('jobPageRevision', this.jobPageRevision);
+        this.showBadge = false;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="stylus">
+.jobsBadge {
+    position:relative;
+    top:1px;
+    left:39px;
+    font-size:small;
+}
+.jobsIcon {
+    width: 28px;
+    height: 28px;
+    padding-top: 4px;
+    margin-right: 10px
+}
+</style>

--- a/docs/.vuepress/components/api3/JobsIcon.vue
+++ b/docs/.vuepress/components/api3/JobsIcon.vue
@@ -1,3 +1,12 @@
+<!--
+  This component displays a checkmark badge when a new job(s) 
+  is posted. It is triggered off the jobPageRevision field in
+  config.js. The browser stores a key in localStorage if the reader
+  has visited the job page and the badge is hidden. So if the browser
+  localStorage key = the config.js field jobPageRevision, the badge 
+  is hidden.
+-->
+
 <template>
   <div>
     <RouterLink to="/api3/introduction/work" class="home-link"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -16,6 +16,8 @@ module.exports = {
   latestBeaconVersion: '/beacon/v0.1/',
   /// Latest/current OIS doc set version.
   latestOisVersion: '/ois/v1.0.0/',
+  /// Job page revision, incremented when a new job(s) is added
+  jobPageRevision: 3,
   head: [['link', { rel: 'icon', href: '/img/small-logo.png' }]],
   title: 'Documentation',
   base: '/',

--- a/docs/dev/custom-components.md
+++ b/docs/dev/custom-components.md
@@ -39,3 +39,19 @@ DocumentSets.vue is placed on the top of
 the different document sets of which some are versioned.
 
 [DocumentSets.vue](https://github.com/api3dao/api3-docs/blob/main/docs/.vuepress/components/DocumentSets.vue)
+
+## JobsIcon.vue
+
+This component displays a checkmark badge when a new job(s) is posted. It is
+triggered off the `jobPageRevision` field in `config.js`. The browser stores a
+key in localStorage (equal to the current value of `jobPageRevision`) if the
+reader has visited the job page followed by the hiding of the badge. So if the
+browser localStorage key `jobPageRevision` equals the config.js field
+`jobPageRevision`, the badge is hidden.
+
+All the logic for the jobs icon and its badge are self contained in this
+component.
+
+Anytime you add a new job to the `workd.md` page, increment the
+`jobPageRevision` field in the `config.js` file by (1) before redeploying the
+docs. Doing so will cause the badge to reappear for all readers.

--- a/docs/dev/custom-components.md
+++ b/docs/dev/custom-components.md
@@ -42,16 +42,29 @@ the different document sets of which some are versioned.
 
 ## JobsIcon.vue
 
-This component displays a checkmark badge when a new job(s) is posted. It is
-triggered off the `jobPageRevision` field in `config.js`. The browser stores a
-key in localStorage (equal to the current value of `jobPageRevision`) if the
-reader has visited the job page followed by the hiding of the badge. So if the
-browser localStorage key `jobPageRevision` equals the config.js field
-`jobPageRevision`, the badge is hidden.
+This component displays a _Job Icon_ that links to a job listing page in the
+API3 document set. It also displays a checkmark badge when a counter
+(`jobPageRevision`) from the `config.js` file is incremented and is larger than
+the counter stored in the browser's localStorage by the SPA.
+
+Therefore, when the user visits the job page the SPA stores a reference to the
+`jobPageRevision` integer locally in the browser's localStorage. The badge will
+be removed for the life of the SPA. So if the browser localStorage key
+`jobPageRevision` equals the config.js field `jobPageRevision`, the badge is
+hidden.
 
 All the logic for the jobs icon and its badge are self contained in this
 component.
 
-Anytime you add a new job to the `workd.md` page, increment the
+Anytime you wish to force the reappearance of the badge, increment the
 `jobPageRevision` field in the `config.js` file by (1) before redeploying the
-docs. Doing so will cause the badge to reappear for all readers.
+docs. Once incremented the badge will eventually reappear. This is accomplished
+by the reader's behavior.
+
+- The reader launches the doc site from a blank browser page thus loading the
+  SPA.
+- The reader reloads the currently displayed SPA.
+
+Not all readers will experience the reappearance of the badge at the same time.
+There is no backend support such as websockets for the docs to implement such
+behavior at his time.


### PR DESCRIPTION
This component displays a _Job Icon_ that links to a job listing page in the
API3 document set. It also displays a checkmark badge when a counter
(`jobPageRevision`) from the `config.js` file is incremented and is larger than
the counter stored in the browser's localStorage by the SPA.

Therefore, when the user visits the job page the SPA stores a reference to the
`jobPageRevision` integer locally in the browser's localStorage. The badge will
be removed for the life of the SPA. So if the browser localStorage key
`jobPageRevision` equals the config.js field `jobPageRevision`, the badge is
hidden.

All the logic for the jobs icon and its badge are self contained in this
component.

Anytime you wish to force the reappearance of the badge, increment the
`jobPageRevision` field in the `config.js` file by (1) before redeploying the
docs. Once incremented the badge will eventually reappear. This is accomplished
by the reader's behavior.

- The reader launches the doc site from a blank browser page thus loading the
  SPA.
- The reader reloads the currently displayed SPA.

Not all readers will experience the reappearance of the badge at the same time.
There is no backend support such as websockets for the docs to implement such
behavior at his time.