### PR TITLE
An518 dynamo db manual removal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
     "BUIDLWEEK",
     "chainapi",
     "collapsable",
-    "frontmatter"
+    "frontmatter",
+    "picklist",
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true

--- a/docs/.vuepress/components/DeleteAirnodeAws.vue
+++ b/docs/.vuepress/components/DeleteAirnodeAws.vue
@@ -1,4 +1,9 @@
 <!--
+This component displays a simple form to guide the reader through
+a manual removal of an Airnode from AWS. Prior to Airnode v0.4 the 
+DynamoDB was used for an Airnode. Because DynamoDB was removed in v0.4
+a new property was added allowing the parent component to show the 
+DynamoDB instructions which are normally hidden.
 https://renatello.com/dynamic-drop-down-list-in-vue-js/
 -->
 
@@ -65,7 +70,7 @@ https://renatello.com/dynamic-drop-down-list-in-vue-js/
         : There are up to five functions to delete.
       </li>
 
-      <li><a :href="'https://' +region + '.console.aws.amazon.com/dynamodbv2/home?region=' + region + '#/tables'" target="_aws-console">DynamoDB<ExternalLinkImage/></a>
+      <li v-show="dynamoDB==='show'"><a :href="'https://' +region + '.console.aws.amazon.com/dynamodbv2/home?region=' + region + '#/tables'" target="_aws-console">DynamoDB<ExternalLinkImage/></a>
         : There is one table to delete.
       </li>
 
@@ -95,6 +100,7 @@ https://renatello.com/dynamic-drop-down-list-in-vue-js/
 <script>
 export default {
   name: 'delete-airnode',
+  props: ['dynamoDB'],
   data: () => ({
     region: 'us-east-1',
   }),

--- a/docs/airnode/v0.2/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.2/grp-providers/docker/deployer-image.md
@@ -115,4 +115,4 @@ docker run -it --rm ^
 
 ## Manual Removal
 
-<DeleteAirnodeAws/>
+<DeleteAirnodeAws dynamoDB='show'/>

--- a/docs/airnode/v0.3/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.3/grp-providers/docker/deployer-image.md
@@ -209,4 +209,4 @@ that you do so using the deployer image's `remove` command.
 
 ### AWS
 
-<DeleteAirnodeAws/>
+<DeleteAirnodeAws dynamoDB="show"/>

--- a/docs/airnode/v0.4/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.4/grp-providers/docker/deployer-image.md
@@ -206,4 +206,4 @@ that you do so using the deployer image's `remove` command.
 
 ### AWS
 
-<DeleteAirnodeAws/>
+<DeleteAirnodeAws />


### PR DESCRIPTION
DynamoDB is no longer used to Airnode `v0.4`+. The manual removal guide (from AWS) now is excludes DynamoDB form its instructions for `v0.4+`.