### PR TITLE
Skip etherscan in CI link check

### DIFF
--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -75,6 +75,7 @@ exclude = [
   "OIS@0.3",
   ".*/NOT-A-REAL-FILE.html",
   "@0.3",
+  "etherscan.io",
 ]
 
 # Exclude URLs contained in a file from checking


### PR DESCRIPTION
Etherscan has been consistently giving 403 errors on CI e.g. #576 