### PR TITLE
Add security schemes to allowed OIS types

### DIFF
--- a/docs/ois/v1.0.0/ois.md
+++ b/docs/ois/v1.0.0/ois.md
@@ -177,8 +177,9 @@ the non-nested application/json content-type is supported.
 Allowed values:
 
 - `apiKey`, `http`: Used by an API to authenticate Airnode.
-- `relayRequesterAddress`, `relayChainId`, `relayChainType`: Allows an API to
-  acquire information about the requester.
+- `relayRequesterAddress`, `relayChainId`, `relayChainType`,
+  `relaySponsorAddress`, `relaySponsorWalletAddress`: Allows an API to acquire
+  information about the requester.
 
 OAS equivalent: `components.securitySchemes.{securitySchemeName}.type`
 


### PR DESCRIPTION
Noted as missing from #542. Failing CI is unrelated and fixed in the other PR.