### PR TITLE
20220210 redirects blank lines

### DIFF
--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -21,7 +21,6 @@
 /pre-alpha/airnode/specifications/reserved-parameters.html /airnode/pre-alpha/airnode/specifications/reserved-parameters.html
 /pre-alpha/guides/docker/deployer-image.html /airnode/pre-alpha/guides/docker/deployer-image.html
 /pre-alpha/protocols/request-response/authorizer.html /airnode/pre-alpha/protocols/request-response/authorizer.html
-
 /airnode/latest/concepts/ /airnode/v0.4/concepts/
 /airnode/latest/concepts/airnode-auth.html /airnode/v0.4/concepts/airnode-auth.html
 /airnode/latest/ /airnode/v0.4/

--- a/docs/dev/redirects.md
+++ b/docs/dev/redirects.md
@@ -74,5 +74,12 @@ was changes to: <code>/r/reserved-parameters
 
 ## Latest Redirects
 
+::: danger Empty Lines
+
+There cannot be empty lines in the body of the file, only at the end. This will
+generate a non-fatal error when building the docs.
+
+:::
+
 <LatestRedirects/>
 {{ $site.pages.path }}


### PR DESCRIPTION
Empty lines in the body of the `redirects` file will cause consoles errors in the docs build script output. These errors are not critical and do not cause the site to build improperly. They are just ugly to look at. Empty lines at the end of the file do not cause this issue.