### PR TITLE
Replace "npx" with "npm exec" for services CLI

### DIFF
--- a/docs/beacon/v0.1/functions/README.md
+++ b/docs/beacon/v0.1/functions/README.md
@@ -36,7 +36,7 @@ generates the minimal project files that will get you started with building your
 application based on beacons. Simply run:
 
 ```
-npx --package @api3/services --call create-beacon-reader-app
+npm exec --package @api3/services --call create-beacon-reader-app
 ```
 
 The CLI tool will ask you for path in which to initialize the project and
@@ -46,9 +46,9 @@ templates in the future. You can also show help or pass the arguments directly:
 
 ```
 # To show help
-npx --package @api3/services --call "create-beacon-reader-app --help"
+npm exec --package @api3/services --call "create-beacon-reader-app --help"
 # To provide the path and template directly through CLI
-npx --package @api3/services --call "create-beacon-reader-app  --path=./my-app --template=javascript-ethers-hardhat"
+npm exec --package @api3/services --call "create-beacon-reader-app  --path=./my-app --template=javascript-ethers-hardhat"
 ```
 
 ::: warning Git needed

--- a/docs/beacon/v0.1/introduction/hackathon.md
+++ b/docs/beacon/v0.1/introduction/hackathon.md
@@ -61,7 +61,7 @@ generates the minimal project files that will get you started with building your
 application based on beacons. Simply run:
 
 ```
-npx --package @api3/services --call create-beacon-reader-app
+npm exec --package @api3/services --call create-beacon-reader-app
 ```
 
 The CLI tool will ask you for path in which to initialize the project and
@@ -71,9 +71,9 @@ templates in the future. You can also show help or pass the arguments directly:
 
 ```
 # To show help
-npx --package @api3/services --call "create-beacon-reader-app --help"
+npm exec --package @api3/services --call "create-beacon-reader-app --help"
 # To provide the path and template directly through CLI
-npx --package @api3/services --call "create-beacon-reader-app  --path=./my-app --template=javascript-ethers-hardhat"
+npm exec --package @api3/services --call "create-beacon-reader-app  --path=./my-app --template=javascript-ethers-hardhat"
 ```
 
 ::: warning Git needed


### PR DESCRIPTION
The `npx` command seems to fail because of the github dependencies that are used in services.
I am saying "seems", because I am not sure, but running `npx --loglevel verbose --package @api3/services --call "create-beacon-reader-app --help"` fails after downloading the utility contracts package.

Also, there are some issues on the NPM repo mentioning problems with github dependencies:
https://github.com/npm/cli/issues/4137
https://github.com/npm/cli/issues/4003

I don't think many people use them in production, so that's why I expect I didn't find the exact issue. Gladly, I empirically found out that replacing `npx` with `npm exec` works. Also `npm i @api3/services` works. Also, after doing `npm i` the `npx` starts to work (likely because it uses the cached package downloaded by npm - also this was probably a reason why the package worked for people testing https://api3dao.atlassian.net/browse/BEC-138).