### PR TITLE
HTTP Gateway maxConcurrency clean-up

### DIFF
--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -182,7 +182,8 @@ tested.
   ...
   "httpGateway": {
     "enabled": true, // The gateway is activated for this Airnode
-    "apiKey": "${HTTP_GATEWAY_API_KEY}" // Gateway apiKey
+    "apiKey": "${HTTP_GATEWAY_API_KEY}", // Gateway apiKey
+    "maxConcurrency": 20
   },
   ...
 },

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -194,7 +194,8 @@ tested.
   ...
   "httpGateway": {
     "enabled": true, // The gateway is activated for this Airnode
-    "apiKey": "${HTTP_GATEWAY_API_KEY}" // Gateway apiKey
+    "apiKey": "${HTTP_GATEWAY_API_KEY}", // Gateway apiKey
+    "maxConcurrency": 20
   },
   ...
 },

--- a/docs/airnode/v0.5/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.5/reference/deployment-files/config-json.md
@@ -191,7 +191,7 @@ An object containing general deployment parameters of an Airnode.
 ```json
 // nodeSettings
 {
-  "nodeVersion": "0.4.0",
+  "nodeVersion": "0.5.0",
   "cloudProvider": {
     "type": "gcp",
     "region": "us-east1",

--- a/docs/airnode/v0.5/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.5/reference/examples/config-cloud.json
@@ -45,7 +45,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.4.0",
+    "nodeVersion": "0.5.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/airnode/v0.5/reference/examples/config-json.md
+++ b/docs/airnode/v0.5/reference/examples/config-json.md
@@ -8,16 +8,6 @@ title: config.json
 
 :::: tabs
 
-::: tab Local Chain/Airnode
-
-You can also view this example
-[config.json](https://github.com/api3dao/airnode/blob/v0.4/packages/airnode-node/config/config.json.example)
-in the Airnode repo.
-
-<<< @/docs/airnode/v0.5/reference/examples/config-local.json
-
-:::
-
 ::: tab Cloud Chain/Airnode
 
 You can also view this example
@@ -25,6 +15,16 @@ You can also view this example
 in the Airnode repo.
 
 <<< @/docs/airnode/v0.5/reference/examples/config-cloud.json
+
+:::
+
+::: tab Local Chain/Airnode
+
+You can also view this example
+[config.json](https://github.com/api3dao/airnode/blob/v0.4/packages/airnode-node/config/config.json.example)
+in the Airnode repo.
+
+<<< @/docs/airnode/v0.5/reference/examples/config-local.json
 
 :::
 

--- a/docs/airnode/v0.5/reference/examples/config-local.json
+++ b/docs/airnode/v0.5/reference/examples/config-local.json
@@ -38,7 +38,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.4.0",
+    "nodeVersion": "0.5.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/airnode/v0.5/reference/templates/config-json.md
+++ b/docs/airnode/v0.5/reference/templates/config-json.md
@@ -75,11 +75,11 @@ building a config.json file.
     "httpGateway": {
       "enabled": true,
       "apiKey": "${HTTP_GATEWAY_API_KEY}", // In secrets.env
-      "maxConcurrency": 20
+      "maxConcurrency": "<FILL_NUMBER>"
     },
     "logFormat": "json",
     "logLevel": "INFO",
-    "nodeVersion": "0.4.0",
+    "nodeVersion": "0.5.0",
     "stage": "<FILL_*>"
   },
   "triggers": {


### PR DESCRIPTION
A few references to the maxConcurrencies for HTTP Gateway missing. A few nodeVersion values set to 0.5.0