### PR TITLE
Reduce branch deployment expiration

### DIFF
--- a/.github/workflows/firebase-deployment.yml
+++ b/.github/workflows/firebase-deployment.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SA_API3_DOCS }}'
-          expires: 30d
+          expires: 7d
           channelId: ${{ steps.get_branch.outputs.branch_name }}
         id: firebase_deploy
 


### PR DESCRIPTION
Necessary to avoid hitting cap on number of live preview deployments