### PR TITLE
Remove references to airnode-client-examples repo

### DIFF
--- a/archived/airnode/v0.2/depr-developing-a-client-contract.md
+++ b/archived/airnode/v0.2/depr-developing-a-client-contract.md
@@ -13,7 +13,6 @@ A [client](../../../../reference/protocols/request-response/client.md) is a cont
 A client is [endorsed](../../../../reference/protocols/request-response/endorsement.md) by a [requester](../../../../reference/protocols/request-response/requester.md), which means that it can specify its request to be fulfilled by the respective requester's [designated wallet](../../../../reference/protocols/request-response/designated-wallet.md).
 
 The Airnode protocol is designed to be flexible, and is meant to serve a variety of use cases.
-See the [Airnode client examples](https://github.com/api3dao/airnode-client-examples/tree/pre-alpha) for some potential design patterns.
 The first step a requester needs to take is to develop and deploy such a client contract.
 
 ## Endorsing your contract

--- a/archived/airnode/v0.2/depr-requester/developing-a-client-contract.md
+++ b/archived/airnode/v0.2/depr-requester/developing-a-client-contract.md
@@ -13,7 +13,6 @@ A [client](../../../reference/protocols/request-response/client.md) is a contrac
 A client is [endorsed](../../../reference/protocols/request-response/endorsement.md) by a [requester](../../../reference/protocols/request-response/requester.md), which means that it can specify its request to be fulfilled by the respective requester's [designated wallet](../../../reference/protocols/request-response/designated-wallet.md).
 
 The Airnode protocol is designed to be flexible, and is meant to serve a variety of use cases.
-See the [Airnode client examples](https://github.com/api3dao/airnode-client-examples/tree/pre-alpha) for some potential design patterns.
 The first step a requester needs to take is to develop and deploy such a client contract.
 
 ## Endorsing your contract

--- a/docs/airnode/pre-alpha/guides/requester/developing-a-client-contract.md
+++ b/docs/airnode/pre-alpha/guides/requester/developing-a-client-contract.md
@@ -11,7 +11,6 @@ A [client](../../protocols/request-response/client.md) is a contract that makes 
 A client is [endorsed](../../protocols/request-response/endorsement.md) by a [requester](../../protocols/request-response/requester.md), which means that it can specify its request to be fulfilled by the respective requester's [designated wallet](../../protocols/request-response/designated-wallet.md).
 
 The Airnode protocol is designed to be flexible, and is meant to serve a variety of use cases.
-See the [Airnode client examples](https://github.com/api3dao/airnode-client-examples/tree/pre-alpha) for some potential design patterns.
 The first step a requester needs to take is to develop and deploy such a client contract.
 
 ## Endorsing your contract

--- a/docs/airnode/pre-alpha/protocols/request-response/client.md
+++ b/docs/airnode/pre-alpha/protocols/request-response/client.md
@@ -13,5 +13,3 @@ Doing so requires the client to be [endorsed](endorsement.md) by the said reques
 
 Note that the client is the contract that makes the request.
 The client may specify the request such that the request is fulfilled by the provider's Airnode calling back another contract.
-
-See the [Airnode client examples](https://github.com/api3dao/airnode-client-examples/tree/pre-alpha).

--- a/docs/airnode/pre-alpha/tutorials/airnode-starter.md
+++ b/docs/airnode/pre-alpha/tutorials/airnode-starter.md
@@ -250,5 +250,4 @@ If you want to learn more, see the following resources:
 - [API3 whitepaper](https://github.com/api3dao/api3-whitepaper) will give you a broad overview of the project.
 - [Medium posts](https://medium.com/api3) explain API3 in smaller, more digestible articles.
 - [@api3/airnode-admin](https://github.com/api3dao/airnode/tree/pre-alpha/packages/admin) lets you interact with the Airnode contract (to create a request, endorse a client, etc.) using a CLI tool.
-- [Airnode client examples](https://github.com/api3dao/airnode-client-examples/tree/pre-alpha) demonstrate different request patterns that the Airnode protocol supports (for example, we used a full request in this starter project).
 


### PR DESCRIPTION
As it no longer exists: https://github.com/api3dao/airnode-client-examples/