### PR TITLE
20220214-corrections

### DIFF
--- a/docs/airnode/v0.5/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.5/reference/examples/config-cloud.json
@@ -30,8 +30,8 @@
     "cloudProvider": {
       "type": "aws",
       "region": "us-east-1",
-      "disableConcurrencyReservations": false,
-      "projectId": "${GCP_PROJECT_ID}" // Used for type=gcp only
+      "disableConcurrencyReservations": false, //Use for (type = gcp | aws) only
+      "projectId": "${GCP_PROJECT_ID}" // Use for (type = gcp) only
     },
     "heartbeat": {
       "enabled": true,

--- a/docs/airnode/v0.5/reference/templates/config-json.md
+++ b/docs/airnode/v0.5/reference/templates/config-json.md
@@ -9,8 +9,9 @@ title: config.json
 A template for an Airnode's configuration file. Below are notations to help
 explain contents of the template.
 
-- `<FILL_*>`: The value added is independent from other fields and a value is
-  needed. These values are not considered secret unless you want them to be.
+- `<FILL_*>, <FILL_NUMBER>, <FILL_BOOLEAN>`: The value added is independent from
+  other fields and a value is needed unless otherwise indicated. These values
+  are not considered secret unless you want them to be.
 
 - `<FILL_OPERATION_PARAMETER_1_NAME>`: If two fields contain the same
   expression, use the same value in them because they are referencing each
@@ -66,18 +67,18 @@ building a config.json file.
     "cloudProvider": {
       "type": "aws", // local, aws or gcp
       "region": "<FILL_*>",
-      "disableConcurrencyReservations": false,
-      "projectId": "${GCP_PROJECT_ID}" // Use for type=gcp only
+      "disableConcurrencyReservations": "<FILL_BOOLEAN>", //Use for (type = gcp | aws) only
+      "projectId": "${GCP_PROJECT_ID}" // Use for (type = gcp) only
     },
     "airnodeWalletMnemonic": "<FILL_*>",
     "heartbeat": {
-      "enabled": true,
+      "enabled": "<FILL_BOOLEAN>",
       "url": "${HEARTBEAT_API_KEY}", // In secrets.env
       "apiKey": "${HEARTBEAT_API_KEY}", // In secrets.env
       "id": "${HEARTBEAT_ID}" // In secrets.env
     },
     "httpGateway": {
-      "enabled": true,
+      "enabled": "<FILL_BOOLEAN>",
       "apiKey": "${HTTP_GATEWAY_API_KEY}", // In secrets.env
       "maxConcurrency": "<FILL_NUMBER>"
     },

--- a/docs/beacon/v0.1/introduction/hackathon.md
+++ b/docs/beacon/v0.1/introduction/hackathon.md
@@ -142,10 +142,9 @@ npm run read-beacon:polygon-mumbai
 
 ::: tip
 
-You can read beacons other than `ETH/USD` by modifying
+You can read Beacons other than `ETH/USD` by modifying
 `scripts/whitelist-reader.js` and `scripts/read-beacon.js`. Refer to the
-[docs](https://docs.api3.org/beacon/v0.1/reference/beacon-ids.html) for a
-complete list.
+[Beacons IDs](../reference/beacon-ids.md) doc for a complete list.
 
 :::
 


### PR DESCRIPTION
- Minor adjustment for `disableConcurrencyReservations`.
- Fixed link for hackathon to use an internal path rather than the full URL which cause the SPA to reload.