### PR TITLE
AN149-fix: Remove `value` from CLI arguments

### DIFF
--- a/docs/airnode/v0.5/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.5/reference/packages/admin-cli.md
@@ -52,7 +52,7 @@ application will not exit until the transaction is confirmed.
 
 CLI commands also support the following transaction overrides as optional
 arguments: `gas-limit`, `gas-price` (legacy transactions), `max-fee` and
-`max-priority-fee` (EIP-1559 transactions), `value` and `nonce`.
+`max-priority-fee` (EIP-1559 transactions) and `nonce`.
 
 ## Using npx
 


### PR DESCRIPTION
Removing `value` as an admin CLI argument as it is not needed in the implementation.