### PR TITLE
Reword the GCP billing information so as not to mislead

### DIFF
--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -126,7 +126,7 @@ Add values for each of the these fields.
 
 3. Make sure you have billing enabled for your project. To do so, you will need
    to pair the project with your bank card, although no charges will be
-   incurred.
+   incurred since the resource usage fits well within the free tier limit.
 
 <!-- 3. Enable the
    [API Gateway](https://console.cloud.google.com/marketplace/product/google/apigateway.googleapis.com?returnUrl=%2Fapi-gateway%2Fapi&project=zzz).

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -125,8 +125,8 @@ Add values for each of the these fields.
    deploying the Airnode for this change to take effect.
 
 3. Make sure you have billing enabled for your project. To do so, you will need
-   to pair the project with your bank card, although no charges will be
-   incurred since the resource usage fits well within the free tier limit.
+   to pair the project with your bank card, although no charges will be incurred
+   since the resource usage fits well within the free tier limit.
 
 <!-- 3. Enable the
    [API Gateway](https://console.cloud.google.com/marketplace/product/google/apigateway.googleapis.com?returnUrl=%2Fapi-gateway%2Fapi&project=zzz).

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -126,7 +126,7 @@ Add values for each of the these fields.
 
 3. Make sure you have billing enabled for your project. To do so, you will need
    to pair the project with your bank card, although no charges will be
-   incurred.
+   incurred since the resource usage fits well within the free tier limit.
 
 <!-- 3. Enable the
    [API Gateway](https://console.cloud.google.com/marketplace/product/google/apigateway.googleapis.com?returnUrl=%2Fapi-gateway%2Fapi&project=zzz).

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -125,8 +125,8 @@ Add values for each of the these fields.
    deploying the Airnode for this change to take effect.
 
 3. Make sure you have billing enabled for your project. To do so, you will need
-   to pair the project with your bank card, although no charges will be
-   incurred since the resource usage fits well within the free tier limit.
+   to pair the project with your bank card, although no charges will be incurred
+   since the resource usage fits well within the free tier limit.
 
 <!-- 3. Enable the
    [API Gateway](https://console.cloud.google.com/marketplace/product/google/apigateway.googleapis.com?returnUrl=%2Fapi-gateway%2Fapi&project=zzz).


### PR DESCRIPTION
In my previous PR, I added the GCP billing information but should have mentioned that no charges are incurred only within the free tier. Emanuel pointed this out for me, so I changed the wording to reflect this. Sorry about the extra work.