### PR TITLE
Change return type of the signed data gateway

### DIFF
--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -208,10 +208,8 @@ The response format is a simple JSON object with the following fields:
 
 ```json
 {
-  "data": {
-    "timestamp": "1648226003",
-    "value": "0x0000000000000000000000000000000000000000000000000000000a571a14c0"
-  },
+  "timestamp": "1648226003",
+  "value": "0x0000000000000000000000000000000000000000000000000000000a571a14c0",
   "signature": "0xa74e4312e2e6fa2de2997ef43e417e3b82d0019ac2a84012300f706f8b213e0d6e1ae9301052ec25b71addae1b1bceb4617779abfc6acd5a951e20a0aaabe6f61b"
 }
 ```


### PR DESCRIPTION
As part of https://github.com/api3dao/airnode/pull/871 I am now changing the signed data gateway to a different return type. See the PR changes for how (the response is flattened).

The docs for the new version are not yet created, so I've just made this a draft PR and leaving it to @wkande to finish.