### PR TITLE
Clarify that timestamp is an UNIX timestamp, fix minor inconsistency

### DIFF
--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -218,7 +218,7 @@ The response format is a simple JSON object with the following fields:
 
 The response format is a simple JSON object with the following fields:
 
-- `data.timestamp` - The timestamp applied to the response.
+- `data.timestamp` - The UNIX timestamp applied to the response.
 - `data.value` - The encoded bytes value that is sent as payload in the
   response. Suitable for use on-chain.
 - `signature` - The response has been signed by Airnode.

--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -218,7 +218,7 @@ The response format is a simple JSON object with the following fields:
 
 The response format is a simple JSON object with the following fields:
 
-- `data.timestamp` - The timestamp applied to the response.
+- `data.timestamp` - The UNIX timestamp applied to the response.
 - `data.value` - The encoded bytes value that is sent as payload in the
   response. Suitable for use on-chain.
 - `signature` - The response has been signed by Airnode.

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -216,9 +216,9 @@ The response format is a simple JSON object with the following fields:
 
 The response format is a simple JSON object with the following fields:
 
-- `data.timestamp` - The timestamp applied to the response.
-- `data.value` - The encoded bytes value that is sent as payload in the
-  response. Suitable for use on-chain.
+- `timestamp` - The UNIX timestamp applied to the response.
+- `value` - The encoded bytes value that is sent as payload in the response.
+  Suitable for use on-chain.
 - `signature` - The response has been signed by Airnode.
 
 :::


### PR DESCRIPTION
I was working on a thing related to the gateway timestamps and my tests were breaking because javascript `Date.getTime()` does not return unix timestamp in seconds, but in miliseconds.

I've added the `UNIX` to make it clear that the gateway return UNIX timestamps which is **in seconds**.