### PR TITLE
Remove duplicated config-json text

### DIFF
--- a/docs/airnode/v0.4/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.4/reference/deployment-files/config-json.md
@@ -182,9 +182,7 @@ valid. Defaults to `0`.-->
 (optional) - The number of blocks that need to pass for the node to start
 ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
 API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json. (optional) - The number of blocks in
-the past that the Airnode deployment should search for requests. Defaults to
-`300` (roughly 1 hour for Ethereum).
+request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.5/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.5/reference/deployment-files/config-json.md
@@ -185,9 +185,7 @@ since the current confirmed block. Defaults to `0`.
 (optional) - The number of blocks that need to pass for the node to start
 ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
 API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json. (optional) - The number of blocks in
-the past that the Airnode deployment should search for requests. Defaults to
-`300` (roughly 1 hour for Ethereum).
+request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.6/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.6/reference/deployment-files/config-json.md
@@ -201,9 +201,7 @@ since the current confirmed block. Defaults to `0`.
 (optional) - The number of blocks that need to pass for the node to start
 ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
 API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json. (optional) - The number of blocks in
-the past that the Airnode deployment should search for requests. Defaults to
-`300` (roughly 1 hour for Ethereum).
+request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -201,9 +201,7 @@ since the current confirmed block. Defaults to `0`.
 (optional) - The number of blocks that need to pass for the node to start
 ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
 API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json. (optional) - The number of blocks in
-the past that the Airnode deployment should search for requests. Defaults to
-`300` (roughly 1 hour for Ethereum).
+request) cannot be found in config.json.
 
 ## nodeSettings
 


### PR DESCRIPTION
Looks like it originated from accidental duplication of `blockHistoryLimit` text