### PR TITLE
Add gasPriceMultiplier config setting for v0.7

### DIFF
--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -149,6 +149,7 @@ object that configures chain-related options.
 - txType: The transaction type to use.
 - priorityFee: An object that configures the EIP-1559 Priority Fee.
 - baseFeeMultiplier: Configures the EIP-1559 Base Fee to Maximum Fee Multiplier.
+- gasPriceMultiplier: Configures the Legacy Gas Price Multiplier
 - fulfillmentGasLimit: The maximum gas limit allowed when Airnode responds to a
   request. If exceeded, the request is marked as failed and will not be repeated
   during Airnode's next run cycle. This is the transaction gas cost the

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -149,7 +149,7 @@ object that configures chain-related options.
 - txType: The transaction type to use.
 - priorityFee: An object that configures the EIP-1559 Priority Fee.
 - baseFeeMultiplier: Configures the EIP-1559 Base Fee to Maximum Fee Multiplier.
-- gasPriceMultiplier: Configures the Legacy Gas Price Multiplier
+- gasPriceMultiplier: Configures the Legacy Gas Price Multiplier.
 - fulfillmentGasLimit: The maximum gas limit allowed when Airnode responds to a
   request. If exceeded, the request is marked as failed and will not be repeated
   during Airnode's next run cycle. This is the transaction gas cost the

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -169,6 +169,13 @@ to`{"value": 3.12, "value": "gwei"}`)
 The resulting Maximum Fee will equal
 `(Base Fee * baseFeeMultiplier) + priorityFee`
 
+#### `options.gasPriceMultiplier`
+
+(optional) - Configures the Legacy Gas Price Multiplier (no multiplier is used
+by default)
+
+The resulting Gas Price will equal `Gas Price * gasPriceMultiplier`
+
 #### `options.fulfillmentGasLimit`
 
 (required) - The maximum gas limit allowed when Airnode responds to a request.


### PR DESCRIPTION
This adds an optional `gasPriceMultiplier` setting for Legacy gas prices (works similar to the `baseFeeMultiplier` but for legacy gas prices) for v0.7.