### PR TITLE
Update request status concepts and configs

### DIFF
--- a/docs/airnode/v0.5/concepts/request.md
+++ b/docs/airnode/v0.5/concepts/request.md
@@ -190,67 +190,6 @@ have been confirmed by the time the next cycle runs. If this happens, the
 transaction is re-submitted with a "faster" transaction fee, overwriting the
 previous transaction.
 
-### Blocked
-
-Airnode is also dependent on the blockchain provider to supply it with the
-onchain data. If the blockchain provider is unavailable for whatever reason, it
-is possible that a request cannot be fully validated, which means that it cannot
-be submitted back to the blockchain. As mentioned above, keeping requests in the
-same order, using the same nonce is critical. Therefore, any request that cannot
-be fully validated due to a blockchain provider error becomes "blocked". This
-means that it and any requests after it are unable to be submitted during the
-current cycle and will be retried during the following cycle. It is important to
-note that this is specific to each requester. e.g. a request sent from requester
-A that becomes "blocked", will not block requests sent from requester B.
-
-The blocked requests get ignored after `ignoreBlockedRequestsAfterBlocks`
-(default value: 20), meaning that they are treated as an Ignored request
-(invalid requests are ignored, e.g., a request whose sponsor and sponsorWallet
-don't match).
-
-#### Blocking cases
-
-In chronological order in the coordinator life-cycle.
-
-1. Airnode RRP has full requests (`makeFullRequest()1`), for which all
-   parameters are specified, or template requests, which specify some of the
-   parameters and specify the ID of a template that contains the rest of the
-   parameters. After fetching templates, if the node can't find the template for
-   a template request, that request gets blocked. This may happen if the
-   blockchain provider is not responding to valid requests (e.g., the node is
-   making too many requests and is being rate-limited).
-
-2. To check authorization for a request, the node needs to know its endpoint ID.
-   Full requests already specify the endpoint ID, and the templates should be
-   fetched for template requests by this point, which specify the endpoint ID.
-   While checking authorizations, if the endpoint ID of a request is not
-   specified, that request gets blocked. This should never happen, because
-   template requests that are missing templates are already blocked in sample #1
-   above.
-
-3. The node makes a static call with some of the request parameters to check if
-   a specific request is authorized (i.e., if it should respond to it). After
-   fetching authorization results, if the node can't find the results for a
-   request, that request gets blocked.This may happen if the blockchain provider
-   is not responding to valid requests (e.g., the node is making too many
-   requests and is being rate-limited).
-
-4. The node invokes a worker for each request with a unique request ID to make
-   the API calls. These workers should return either with a payload or an error
-   (if the call has timed our or the API errored). While mapping the worker
-   responses back (referred to as “disaggregation” in the code), if the node
-   can't find the response for a request, that request gets blocked. In theory
-   this should never happen.
-
-### Ignore
-
-If the Airnode cannot even fail a request (e.g., the requester is not sponsored
-by the sponsor), the request gets ignored.
-
-After X blocks (20 by default for EVM chains), any requests that would become
-"blocked", will instead become "ignored". This means that Airnode will stop
-attempting to process the request in order to process later requests.
-
 ## Check if request is awaiting fulfillment
 
 There is a convenience method in AirnodeRrp.sol called

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -94,8 +94,7 @@ Below is a simple chain array with a single chain provider.
     },
     "type": "evm",
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   }
 ],
 ```
@@ -209,12 +208,6 @@ requests. Defaults to `300` (roughly 1 hour for Ethereum).
 [<InfoBtnGreen/>](../../../reference/deployment-files/config-json.md#minconfirmations)
 The number of confirmations required for a request to be considered valid.
 Defaults to `0`.
-
-#### ignoreBlockedRequestsAfterBlocks
-
-[<InfoBtnGreen/>](../../../reference/deployment-files/config-json.md#ignoreblockedrequestsafterblocks)
-The number of blocks that need to pass for the node to start ignoring blocked
-requests. Defaults to `20`.
 
 ### nodeSettings
 

--- a/docs/airnode/v0.5/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.5/reference/deployment-files/config-json.md
@@ -72,8 +72,7 @@ respective parameters.
       "baseFeeMultiplier": 2
     },
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   },
   {
     "maxConcurrency": 100,
@@ -178,14 +177,6 @@ search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
 (optional) - The number of confirmations required for a request to be considered
 valid. Minimum confirmations refers to the number of blocks that have elapsed
 since the current confirmed block. Defaults to `0`.
-
-### `ignoreBlockedRequestsAfterBlocks`
-
-[<InfoBtnBlue/>](../../grp-providers/guides/build-an-airnode/configuring-airnode.md#ignoreblockedrequestsafterblocks)
-(optional) - The number of blocks that need to pass for the node to start
-ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
-API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.5/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.5/reference/examples/config-cloud.json
@@ -22,8 +22,7 @@
         "baseFeeMultiplier": 2
       },
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.5/reference/examples/config-local.json
+++ b/docs/airnode/v0.5/reference/examples/config-local.json
@@ -22,8 +22,7 @@
         "baseFeeMultiplier": 2
       },
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.5/reference/templates/config-json.md
+++ b/docs/airnode/v0.5/reference/templates/config-json.md
@@ -60,8 +60,7 @@ building a config.json file.
         "baseFeeMultiplier": "<FILL_NUMBER>"
       },
       "blockHistoryLimit": "<FILL_*>",
-      "minConfirmations": "<FILL_*>",
-      "ignoreBlockedRequestsAfterBlocks": "<FILL_*>"
+      "minConfirmations": "<FILL_*>"
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.6/concepts/request.md
+++ b/docs/airnode/v0.6/concepts/request.md
@@ -191,67 +191,6 @@ have been confirmed by the time the next cycle runs. If this happens, the
 transaction is re-submitted with a "faster" transaction fee, overwriting the
 previous transaction.
 
-### Blocked
-
-Airnode is also dependent on the blockchain provider to supply it with the
-onchain data. If the blockchain provider is unavailable for whatever reason, it
-is possible that a request cannot be fully validated, which means that it cannot
-be submitted back to the blockchain. As mentioned above, keeping requests in the
-same order, using the same nonce is critical. Therefore, any request that cannot
-be fully validated due to a blockchain provider error becomes "blocked". This
-means that it and any requests after it are unable to be submitted during the
-current cycle and will be retried during the following cycle. It is important to
-note that this is specific to each requester. e.g. a request sent from requester
-A that becomes "blocked", will not block requests sent from requester B.
-
-The blocked requests get ignored after `ignoreBlockedRequestsAfterBlocks`
-(default value: 20), meaning that they are treated as an Ignored request
-(invalid requests are ignored, e.g., a request whose sponsor and sponsorWallet
-don't match).
-
-#### Blocking cases
-
-In chronological order in the coordinator life-cycle.
-
-1. Airnode RRP has full requests (`makeFullRequest()1`), for which all
-   parameters are specified, or template requests, which specify some of the
-   parameters and specify the ID of a template that contains the rest of the
-   parameters. After fetching templates, if the node can't find the template for
-   a template request, that request gets blocked. This may happen if the
-   blockchain provider is not responding to valid requests (e.g., the node is
-   making too many requests and is being rate-limited).
-
-2. To check authorization for a request, the node needs to know its endpoint ID.
-   Full requests already specify the endpoint ID, and the templates should be
-   fetched for template requests by this point, which specify the endpoint ID.
-   While checking authorizations, if the endpoint ID of a request is not
-   specified, that request gets blocked. This should never happen, because
-   template requests that are missing templates are already blocked in sample #1
-   above.
-
-3. The node makes a static call with some of the request parameters to check if
-   a specific request is authorized (i.e., if it should respond to it). After
-   fetching authorization results, if the node can't find the results for a
-   request, that request gets blocked.This may happen if the blockchain provider
-   is not responding to valid requests (e.g., the node is making too many
-   requests and is being rate-limited).
-
-4. The node invokes a worker for each request with a unique request ID to make
-   the API calls. These workers should return either with a payload or an error
-   (if the call has timed our or the API errored). While mapping the worker
-   responses back (referred to as “disaggregation” in the code), if the node
-   can't find the response for a request, that request gets blocked. In theory
-   this should never happen.
-
-### Ignore
-
-If the Airnode cannot even fail a request (e.g., the requester is not sponsored
-by the sponsor), the request gets ignored.
-
-After X blocks (20 by default for EVM chains), any requests that would become
-"blocked", will instead become "ignored". This means that Airnode will stop
-attempting to process the request in order to process later requests.
-
 ## Check if request is awaiting fulfillment
 
 There is a convenience method in AirnodeRrpV0.sol called

--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -96,8 +96,7 @@ Below is a simple chain array with a single chain provider.
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   }
 ],
 ```
@@ -218,12 +217,6 @@ requests. Defaults to `300` (roughly 1 hour for Ethereum).
 [<InfoBtnGreen/>](../../../reference/deployment-files/config-json.md#minconfirmations)
 The number of confirmations required for a request to be considered valid.
 Defaults to `0`.
-
-#### ignoreBlockedRequestsAfterBlocks
-
-[<InfoBtnGreen/>](../../../reference/deployment-files/config-json.md#ignoreblockedrequestsafterblocks)
-The number of blocks that need to pass for the node to start ignoring blocked
-requests. Defaults to `20`.
 
 ### nodeSettings
 

--- a/docs/airnode/v0.6/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.6/reference/deployment-files/config-json.md
@@ -78,8 +78,7 @@ respective parameters.
     "maxConcurrency": 100,
 
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   },
   {
     "authorizers": [],
@@ -104,8 +103,7 @@ respective parameters.
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   }
 ]
 ```
@@ -195,14 +193,6 @@ search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
 (optional) - The number of confirmations required for a request to be considered
 valid. Minimum confirmations refers to the number of blocks that have elapsed
 since the current confirmed block. Defaults to `0`.
-
-### `ignoreBlockedRequestsAfterBlocks`
-
-[<InfoBtnBlue/>](../../grp-providers/guides/build-an-airnode/configuring-airnode.md#ignoreblockedrequestsafterblocks)
-(optional) - The number of blocks that need to pass for the node to start
-ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
-API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.6/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.6/reference/examples/config-cloud.json
@@ -23,8 +23,7 @@
       },
       "maxConcurrency": 100,
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.6/reference/examples/config-local.json
+++ b/docs/airnode/v0.6/reference/examples/config-local.json
@@ -23,8 +23,7 @@
       "maxConcurrency": 100,
       "fulfillmentGasLimit": 500000,
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.6/reference/templates/config-json.md
+++ b/docs/airnode/v0.6/reference/templates/config-json.md
@@ -62,8 +62,7 @@ building a config.json file.
       },
       "maxConcurrency": <FILL_NUMBER>,
       "blockHistoryLimit": "<FILL_*>",
-      "minConfirmations": "<FILL_*>",
-      "ignoreBlockedRequestsAfterBlocks": "<FILL_*>"
+      "minConfirmations": "<FILL_*>"
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.7/concepts/request.md
+++ b/docs/airnode/v0.7/concepts/request.md
@@ -191,67 +191,6 @@ have been confirmed by the time the next cycle runs. If this happens, the
 transaction is re-submitted with a "faster" transaction fee, overwriting the
 previous transaction.
 
-### Blocked
-
-Airnode is also dependent on the blockchain provider to supply it with the
-onchain data. If the blockchain provider is unavailable for whatever reason, it
-is possible that a request cannot be fully validated, which means that it cannot
-be submitted back to the blockchain. As mentioned above, keeping requests in the
-same order, using the same nonce is critical. Therefore, any request that cannot
-be fully validated due to a blockchain provider error becomes "blocked". This
-means that it and any requests after it are unable to be submitted during the
-current cycle and will be retried during the following cycle. It is important to
-note that this is specific to each requester. e.g. a request sent from requester
-A that becomes "blocked", will not block requests sent from requester B.
-
-The blocked requests get ignored after `ignoreBlockedRequestsAfterBlocks`
-(default value: 20), meaning that they are treated as an Ignored request
-(invalid requests are ignored, e.g., a request whose sponsor and sponsorWallet
-don't match).
-
-#### Blocking cases
-
-In chronological order in the coordinator life-cycle.
-
-1. Airnode RRP has full requests (`makeFullRequest()1`), for which all
-   parameters are specified, or template requests, which specify some of the
-   parameters and specify the ID of a template that contains the rest of the
-   parameters. After fetching templates, if the node can't find the template for
-   a template request, that request gets blocked. This may happen if the
-   blockchain provider is not responding to valid requests (e.g., the node is
-   making too many requests and is being rate-limited).
-
-2. To check authorization for a request, the node needs to know its endpoint ID.
-   Full requests already specify the endpoint ID, and the templates should be
-   fetched for template requests by this point, which specify the endpoint ID.
-   While checking authorizations, if the endpoint ID of a request is not
-   specified, that request gets blocked. This should never happen, because
-   template requests that are missing templates are already blocked in sample #1
-   above.
-
-3. The node makes a static call with some of the request parameters to check if
-   a specific request is authorized (i.e., if it should respond to it). After
-   fetching authorization results, if the node can't find the results for a
-   request, that request gets blocked.This may happen if the blockchain provider
-   is not responding to valid requests (e.g., the node is making too many
-   requests and is being rate-limited).
-
-4. The node invokes a worker for each request with a unique request ID to make
-   the API calls. These workers should return either with a payload or an error
-   (if the call has timed our or the API errored). While mapping the worker
-   responses back (referred to as “disaggregation” in the code), if the node
-   can't find the response for a request, that request gets blocked. In theory
-   this should never happen.
-
-### Ignore
-
-If the Airnode cannot even fail a request (e.g., the requester is not sponsored
-by the sponsor), the request gets ignored.
-
-After X blocks (20 by default for EVM chains), any requests that would become
-"blocked", will instead become "ignored". This means that Airnode will stop
-attempting to process the request in order to process later requests.
-
 ## Check if request is awaiting fulfillment
 
 There is a convenience method in AirnodeRrpV0.sol called

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -96,8 +96,7 @@ Below is a simple chain array with a single chain provider.
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   }
 ],
 ```
@@ -167,7 +166,6 @@ The below links offer details for each field:
 - [maxConcurrency](../../../reference/deployment-files/config-json.md#maxconcurrency)
 - [blockHistoryLimit](../../../reference/deployment-files/config-json.md#blockhistorylimit)
 - [minConfirmations](../../../reference/deployment-files/config-json.md#minconfirmations)
-- [ignoreBlockedRequestsAfterBlocks](../../../reference/deployment-files/config-json.md#ignoreblockedrequestsafterblocks)
 
 ### nodeSettings
 

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -78,8 +78,7 @@ respective parameters.
     "maxConcurrency": 100,
 
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   },
   {
     "authorizers": [],
@@ -104,8 +103,7 @@ respective parameters.
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
-    "minConfirmations": 0,
-    "ignoreBlockedRequestsAfterBlocks": 20
+    "minConfirmations": 0
   }
 ]
 ```
@@ -212,13 +210,6 @@ search for requests. Defaults to `300` (roughly 1 hour for Ethereum).
 (optional) - The number of confirmations required for a request to be considered
 valid. Minimum confirmations refers to the number of blocks that have elapsed
 since the current confirmed block. Defaults to `0`.
-
-### `ignoreBlockedRequestsAfterBlocks`
-
-(optional) - The number of blocks that need to pass for the node to start
-ignoring blocked requests. Defaults to `20`. A request is blocked whenever the
-API call cannot be made. For example, endpoint (specified by its id in the
-request) cannot be found in config.json.
 
 ## nodeSettings
 

--- a/docs/airnode/v0.7/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.7/reference/examples/config-cloud.json
@@ -23,8 +23,7 @@
       },
       "maxConcurrency": 100,
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.7/reference/examples/config-local.json
+++ b/docs/airnode/v0.7/reference/examples/config-local.json
@@ -23,8 +23,7 @@
       "maxConcurrency": 100,
       "fulfillmentGasLimit": 500000,
       "blockHistoryLimit": 300,
-      "minConfirmations": 0,
-      "ignoreBlockedRequestsAfterBlocks": 20
+      "minConfirmations": 0
     }
   ],
   "nodeSettings": {

--- a/docs/airnode/v0.7/reference/templates/config-json.md
+++ b/docs/airnode/v0.7/reference/templates/config-json.md
@@ -62,8 +62,7 @@ building a config.json file.
       },
       "maxConcurrency": <FILL_NUMBER>,
       "blockHistoryLimit": "<FILL_*>",
-      "minConfirmations": "<FILL_*>",
-      "ignoreBlockedRequestsAfterBlocks": "<FILL_*>"
+      "minConfirmations": "<FILL_*>"
     }
   ],
   "nodeSettings": {


### PR DESCRIPTION
The process of assigning requests a status, including blocked and ignored, was removed from Airnode prior to v0.5 [via this commit](https://github.com/api3dao/airnode/commit/0ed6277bdd789bfa48d97e6c5d179c9ba357a520). As part of that `ignoreBlockedRequestsAfterBlocks` was also removed.