### PR TITLE
Add information about Selinux to Providers > Docker Images > Overview

### DIFF
--- a/docs/airnode/v0.5/grp-providers/docker/README.md
+++ b/docs/airnode/v0.5/grp-providers/docker/README.md
@@ -21,6 +21,8 @@ to using `npx`.
 To use these images first install [Docker](https://docs.docker.com/get-docker/)
 if it is not present on your system.
 
+If using a Linux distribution that enforces Selinux policies, make sure allow the Docker images access to the host directory by [creating an appropriate rule](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker). 
+
 - The [Airnode deployer image](./deployer-image.md) deploys the node in the form
   of serverless functions to a serverless cloud provider (e.g. AWS Lambda).
 

--- a/docs/airnode/v0.6/grp-providers/docker/README.md
+++ b/docs/airnode/v0.6/grp-providers/docker/README.md
@@ -22,6 +22,8 @@ to using `npx`.
 To use these images first install [Docker](https://docs.docker.com/get-docker/)
 if it is not present on your system.
 
+If using a Linux distribution that enforces Selinux policies, make sure allow the Docker images access to the host directory by [creating an appropriate rule](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker). 
+
 - The [Airnode deployer image](./deployer-image.md) deploys the node in the form
   of serverless functions to a serverless cloud provider (e.g. AWS Lambda).
 

--- a/docs/airnode/v0.7/grp-providers/docker/README.md
+++ b/docs/airnode/v0.7/grp-providers/docker/README.md
@@ -21,6 +21,8 @@ to using `npx`.
 
 To use these images first install [Docker](https://docs.docker.com/get-docker/)
 if it is not present on your system.
+ 
+If using a Linux distribution that enforces Selinux policies, make sure allow the Docker images access to the host directory by [creating an appropriate rule](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker). 
 
 - The [Airnode deployer image](./deployer-image.md) deploys the node in the form
   of serverless functions to a serverless cloud provider (e.g. AWS Lambda).


### PR DESCRIPTION
This PR adds information regarding Selinux in case people run into permission errors.