### PR TITLE
Update Api3Voting.sol link

### DIFF
--- a/docs/dao-members/contract-architecture/voting.md
+++ b/docs/dao-members/contract-architecture/voting.md
@@ -26,7 +26,7 @@ commands a larger treasury and can update all DAO settings, while the secondary
 commands a much smaller treasury and can update some of the DAO settings.
 
 See the
-[Api3Voting.sol](https://github.com/api3dao/api3-dao/tree/main/packages/dao/contracts)
+[Api3Voting.sol](https://github.com/api3dao/api3-dao/blob/main/packages/api3-voting/contracts/Api3Voting.sol)
 contract code and the Aragon contracts it inherits from.
 
 - BaseTemplate


### PR DESCRIPTION
This contract was in a different directory than what the existing link points to.
~~Also fixes formatting of a previous commit.~~