### PR TITLE
Content reflective of data-feed-reader-example

### DIFF
--- a/docs/data-feeds/developers/README.md
+++ b/docs/data-feeds/developers/README.md
@@ -17,12 +17,40 @@ The
 contract serves data feed values to any dApp with the appropriate permissions.
 The contract is simple to use and returns immediate data feed values.
 
-::: tip Data feed preview access
+## Starter Project
 
-Currently access to data feeds does not require a subscription during the
-current preview period.
+The
+[data-feed-reader-example](https://github.com/api3dao/data-feed-reader-example)
+starter is an example project for reading API3 data feeds on the Polygon
+testnet. Be sure to read through the
+[README.md](https://github.com/api3dao/data-feed-reader-example/blob/main/README.md)
+and some of the example code such as the
+[DataFeedReaderExample.sol](https://github.com/api3dao/data-feed-reader-example/blob/main/contracts/DataFeedReaderExample.sol)
+contract. Read through this entire page before running the starter project to
+better understand some of the terms and concepts mentioned. Finally follow the
+instruction in the README to get acquainted with reading data feeds.
 
-:::
+## Subscriptions
+
+`DapiServer.sol` will check that the requester has a subscription for each data
+feed it may attempt to read. During the _preview period_, all data feeds on
+production networks are accessible with a free (limited time offer)
+subscription. Please go to the
+[Data Feed Subscription](https://forms.monday.com/forms/embed/f44d0ed9dfd0154885f48fdb3b87a489?r=use1)
+inquiry page to request data feed access on production networks. See
+[Chains and Contracts](../reference/chains.md) which includes supported
+production networks as well as testnets.
+
+### Testnets
+
+For testnets like polygon-testnet, developers can self-subscribe to use any data
+feed. During the deployment flow of your smart contract that reads a data feed,
+add code that self-subscribes to the desired data feed. The following scripts
+from the [Starter Project](./#starter-project) detail how this is done. Please
+be sure to explore the starter project in its entirety.
+
+- [allow-to-read-with-id.js](https://github.com/api3dao/data-feed-reader-example/blob/main/scripts/allow-to-read-with-id.js)
+- [allow-to-read-with-name.js](https://github.com/api3dao/data-feed-reader-example/blob/main/scripts/allow-to-read-with-name.js)
 
 ## IDs and Names
 
@@ -47,18 +75,6 @@ value of a Beacon set. A dAPI data feed is a live data point associated with
 Beacons could change as needed) is always more favorable, e.g., in the context
 of an asset price data feed.
 
-## Starter Project
-
-This
-[data-feed-reader-example](https://github.com/api3dao/data-feed-reader-example)
-starter is an example project for reading API3 data feeds on the Polygon
-testnet. Be sure to read through the
-[README.md](https://github.com/api3dao/data-feed-reader-example/blob/main/README.md)
-and some of the example code such as the
-[DataFeedReaderExample.sol](https://github.com/api3dao/data-feed-reader-example/blob/main/contracts/DataFeedReaderExample.sol)
-smart contract. Finally follow the instruction in the README to get acquainted
-with reading data feeds.
-
 ## DapiServer Functions
 
 - [readDataFeedWithId()](./read-data-feed-with-id.md) - Returns a value and
@@ -72,7 +88,7 @@ with reading data feeds.
 - [readerCanReadDataFeed()](./reader-can-read-datafeed.md) - Whether a reader
   can read a data feed.
 - [dataFeedIdToReaderToWhitelistStatus()](./data-feed-id-to-reader-to-whitelist-status.md) -
-  Details about the whitelist status of a reader address.
+  Details about the subscription status of a reader address.
 
 ## Resources
 

--- a/docs/data-feeds/developers/data-feed-id-to-reader-to-whitelist-status.md
+++ b/docs/data-feeds/developers/data-feed-id-to-reader-to-whitelist-status.md
@@ -14,21 +14,14 @@ folder: dApp Developers
 
 For on-chain smart contracts, the function
 [dataFeedIdToReaderToWhitelistStatus()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L791-L806)
-returns the `expirationTimestamp` and `indefiniteWhitelistCount` of a reader for
-the specified dAPI `datafeedId`.
+returns [subscription](./#subscriptions) information with the
+`expirationTimestamp` and `indefiniteWhitelistCount` of a reader for the
+specified data feed.
 
 The reader will not be able to read the dAPI data feed past the
-expirationTimestamp (assuming their `indefiniteWhitelistCount` is 0 ).
-
-If the `indefiniteWhitelistCount` is greater than 0 , the reader will be able to
-read the dAPI data feed indefinitely (regardless of the value of
-`expirationTimestamp`).
-
-Please contact the [API3 Business Development API Team](https://api3.org) to be
-whitelisted.
-
-Calling from off-chain code (_using a library such as `ether.js`_) is not
-subject to whitelisting. Off-chain code is beyond the scope of this doc.
+expirationTimestamp (assuming their `indefiniteWhitelistCount` is 0 ). If the
+`indefiniteWhitelistCount` is greater than 0 , the reader will be able to read
+the data feed indefinitely (regardless of the value of `expirationTimestamp`).
 
 ## Example Code
 

--- a/docs/data-feeds/developers/read-data-feed-value-with-dapi-name.md
+++ b/docs/data-feeds/developers/read-data-feed-value-with-dapi-name.md
@@ -16,15 +16,7 @@ Reading a dAPI Data Feed value and timestamp using a dAPI `_dapiName` is simple
 and straight forward. For on-chain smart contracts the `msg.sender` argument
 received by the function
 [readDataFeedValueWithDapiName()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L749-L765)
-must be whitelisted.
-
-::: tip Get Whitelisted
-
-Please contact the
-[API3 Business Development API Team](https://api3dao.typeform.com/to/O1Uvxc8m)
-about dAPI Data Feed whitelisting.
-
-:::
+must have a [subscription](./#subscriptions) for the data feed requested.
 
 Calling from off-chain code (_using a library such as `ether.js`_) is not
 subject to whitelisting. Off-chain code is beyond the scope of this doc.

--- a/docs/data-feeds/developers/read-data-feed-value-with-id.md
+++ b/docs/data-feeds/developers/read-data-feed-value-with-id.md
@@ -16,15 +16,7 @@ Reading a dAPI Data Feed value using the dAPI `_datafeedId` is simple and
 straight forward. For on-chain smart contracts the `msg.sender` argument
 received by the function
 [readDataFeedValueWithId()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L708-L721)
-must be whitelisted.
-
-::: tip Get Whitelisted
-
-Please contact the
-[API3 Business Development API Team](https://api3dao.typeform.com/to/O1Uvxc8m)
-about dAPI Data Feed whitelisting.
-
-:::
+must have a [subscription](./#subscriptions) for the data feed requested.
 
 Calling from off-chain code (_using a library such as `ether.js`_) is not
 subject to whitelisting. Off-chain code is beyond the scope of this doc.

--- a/docs/data-feeds/developers/read-data-feed-with-dapi-name.md
+++ b/docs/data-feeds/developers/read-data-feed-with-dapi-name.md
@@ -16,15 +16,7 @@ Reading a dAPI Data Feed value and timestamp using a dAPI `_dapiName` is simple
 and straight forward. For on-chain smart contracts the `msg.sender` argument
 received by the function
 [readDataFeedWithDapiName()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L729-L744)
-must be whitelisted.
-
-::: tip Get Whitelisted
-
-Please contact the
-[API3 Business Development API Team](https://api3dao.typeform.com/to/O1Uvxc8m)
-about dAPI Data Feed whitelisting.
-
-:::
+must have a [subscription](./#subscriptions) for the data feed requested.
 
 Calling from off-chain code (_using a library such as `ether.js`_) is not
 subject to whitelisting. Off-chain code is beyond the scope of this doc.

--- a/docs/data-feeds/developers/read-data-feed-with-id.md
+++ b/docs/data-feeds/developers/read-data-feed-with-id.md
@@ -16,15 +16,7 @@ Reading a dAPI Data Feed value and timestamp using the dAPI `_datafeedId` is
 simple and straight forward. For on-chain smart contracts the `msg.sender`
 argument received by the function
 [readDataFeedWithId()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L691-L703)
-must be whitelisted.
-
-::: tip Get Whitelisted
-
-Please contact the
-[API3 Business Development API Team](https://api3dao.typeform.com/to/O1Uvxc8m)
-about dAPI Data Feed whitelisting.
-
-:::
+must have a [subscription](./#subscriptions) for the data feed requested.
 
 Calling from off-chain code (_using a library such as `ether.js`_) is not
 subject to whitelisting. Off-chain code is beyond the scope of this doc.

--- a/docs/data-feeds/developers/reader-can-read-datafeed.md
+++ b/docs/data-feeds/developers/reader-can-read-datafeed.md
@@ -15,11 +15,8 @@ folder: dApp Developers
 For on-chain smart contracts, the function
 [readerCanReadDataFeed()](https://github.com/api3dao/airnode-protocol-v1/blob/v0.5.0/contracts/dapis/DapiServer.sol#L771-L781)
 returns true if the `reader` parameter can access the `dataFeedId` parameter
-meaning that the reader address has been whitelisted. Please contact the
-[API3 Business Development API Team](https://api3.org) to be whitelisted.
-
-Calling from off-chain code (_using a library such as `ether.js`_) is not
-subject to whitelisting. Off-chain code is beyond the scope of this doc.
+meaning that the reader address has the appropriate data feed subscription. See
+[Subscriptions](./#subscriptions) for more information about data feed access.
 
 ## Example Code
 


### PR DESCRIPTION
The only thing still outstanding is the canRead functions only accepting `_datafeedId`. There is a question out on Slack about it.