### PR TITLE
Document withdrawalRemainder in config.json

### DIFF
--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -163,6 +163,7 @@ The below links offer details for each field:
   - [options.baseFeeMultiplier](../../../reference/deployment-files/config-json.md#options-basefeemultiplier)
   - [options.gasPriceMultiplier](../../../reference/deployment-files/config-json.md#options-gaspricemultiplier)
   - [options.fulfillmentGasLimit](../../../reference/deployment-files/config-json.md#options-fulfillmentgaslimit)
+  - [options.withdrawalRemainder](../../../reference/deployment-files/config-json.md#options-withdrawalremainder)
 - [maxConcurrency](../../../reference/deployment-files/config-json.md#maxconcurrency)
 - [blockHistoryLimit](../../../reference/deployment-files/config-json.md#blockhistorylimit)
 - [minConfirmations](../../../reference/deployment-files/config-json.md#minconfirmations)

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -99,7 +99,11 @@ respective parameters.
         "unit": "gwei"
       },
       "baseFeeMultiplier": 2,
-      "fulfillmentGasLimit": 500000
+      "fulfillmentGasLimit": 500000,
+      "withdrawalRemainder": {
+        "value": 0,
+        "unit": "wei"
+      }
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
@@ -182,6 +186,31 @@ The resulting Gas Price will equal `Gas Price * gasPriceMultiplier`
 (required) - The maximum gas limit allowed when Airnode responds to a request,
 paid by the requester. If exceeded, the request is marked as failed and will not
 be repeated during Airnode's next run cycle.
+
+#### `options.withdrawalRemainder`
+
+(optional) - An object of the form `{"value": 0, "unit": "wei"}` that configures
+the amount to subtract from the funds returned to the sponsor when making a
+[withdrawal](../../concepts/sponsor.md#withdrawals). Defaults to zero and is
+relevant only for some chains e.g.
+[Optimism](../chain-idiosyncrasies.md#optimism).
+
+##### `options.withdrawalRemainder.value`
+
+(required) - A number specifying the `withdrawalRemainder` value.
+
+##### `options.withdrawalRemainder.unit`
+
+(required) - The unit of the `withdrawalRemainder` value. It can be one of the
+following:
+
+- `wei`
+- `kwei`
+- `mwei`
+- `gwei`
+- `szabo`
+- `finney`
+- `ether`
 
 ### `maxConcurrency`
 


### PR DESCRIPTION
Documentation of https://github.com/api3dao/airnode/pull/1131

To be merged after #789 because of a link in this PR that points to that new page.

I opted to include `withdrawalRemainder` only in the `Reference` page `json`  and not within the `json` example provided in the `Configuring Airnode` guide as this new parameter only applies (so far) to Optimism and is therefore optional (and distracting) for the majority of chains.