### PR TITLE
Fix endpoint IDs in docs

### DIFF
--- a/archived/airnode/v0.2/config-json.md
+++ b/archived/airnode/v0.2/config-json.md
@@ -54,7 +54,7 @@ in the Airnode repo.
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353",
+        "endpointId": "0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6",
         "oisTitle": "Currency Converter API",
         "endpointName": "convertToUSD"
       }

--- a/archived/airnode/v0.2/old-airnode-starter-files/example-config-airnode-starter.json
+++ b/archived/airnode/v0.2/old-airnode-starter-files/example-config-airnode-starter.json
@@ -133,7 +133,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xe811f1a71c3f0d159472ec8bfa281483d74920e26a9d116de667858e12d1943e",
         "oisTitle": "CoinGecko-starter-example",
         "endpointName": "coinMarketData"
       }

--- a/archived/airnode/v0.2/old-airnode-starter-files/tutorial-config.json
+++ b/archived/airnode/v0.2/old-airnode-starter-files/tutorial-config.json
@@ -132,7 +132,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xe811f1a71c3f0d159472ec8bfa281483d74920e26a9d116de667858e12d1943e",
         "oisTitle": "CoinGecko-starter-example",
         "endpointName": "coinMarketData"
       }

--- a/archived/airnode/v0.5/http-gateway.md
+++ b/archived/airnode/v0.5/http-gateway.md
@@ -64,14 +64,14 @@ on-chain and only some via the gateway, or vise versa.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/pre-alpha/tutorials/airnode-starter.md
+++ b/docs/airnode/pre-alpha/tutorials/airnode-starter.md
@@ -156,7 +156,7 @@ Your deployed Airnode will use these funds to make the transaction that will cre
 
 ### Make your endpoint publicly accessible
 
-`config.json`defines an [endpoint](../protocols/request-response/endpoint.md) named`coinMarketData`, whose [endpoint ID](../protocols/request-response/endpoint.md#endpointid) is `0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c`. Endpoints are not publicly accessible by default, so you will have to make a transaction for this. Run the following to set your endpoint's [authorizers](../protocols/request-response/authorizer.md) to `[0x0000000000000000000000000000000000000000]`, which makes it [publicly accessible](../guides/provider/setting-authorizers.md#allow-all):
+`config.json`defines an [endpoint](../protocols/request-response/endpoint.md) named`coinMarketData`, whose [endpoint ID](../protocols/request-response/endpoint.md#endpointid) is `0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6`. Endpoints are not publicly accessible by default, so you will have to make a transaction for this. Run the following to set your endpoint's [authorizers](../protocols/request-response/authorizer.md) to `[0x0000000000000000000000000000000000000000]`, which makes it [publicly accessible](../guides/provider/setting-authorizers.md#allow-all):
 ```sh
 npm run update-authorizers
 ```

--- a/docs/airnode/pre-alpha/tutorials/config-examples/config-example-json.md
+++ b/docs/airnode/pre-alpha/tutorials/config-examples/config-example-json.md
@@ -143,7 +143,7 @@ title: config.example.json
   "triggers": {
     "request": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xe811f1a71c3f0d159472ec8bfa281483d74920e26a9d116de667858e12d1943e",
         "oisTitle": "CoinGecko-starter-example",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.2/grp-providers/guides/build-an-airnode/http-gateway.md
+++ b/docs/airnode/v0.2/grp-providers/guides/build-an-airnode/http-gateway.md
@@ -94,7 +94,7 @@ use
 | parameter         | in     | CURL options                                             |
 | ----------------- | ------ | -------------------------------------------------------- |
 | x-api-key         | header | `-H 'x-api-key: 8d890a46-799d-48b3-a337-8531e23dfe8e'`   |
-| endpointId        | path   | `0xf466b8feec...99e9f9f90453c`                           |
+| endpointId        | path   | `0x6db9e3e3d...c7025f5c27af6`                            |
 | &lt;user-defined> | body   | `-d '{"parameters": {"param1": "string", "param2": 5}}'` |
 
 Replace `<httpGatewayUrl>` in the example below with your gateway URL from the

--- a/docs/airnode/v0.2/grp-providers/tutorial/README.md
+++ b/docs/airnode/v0.2/grp-providers/tutorial/README.md
@@ -214,7 +214,7 @@ Breaking down the URL in the CURL command below:
 
 - `<httpGatewayUrl>`: The base URL to the gateway, found in the `receipts.json`
   file. Update the placeholder in the CURL example below with its value.
-- `0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c`: Passed
+- `0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6`: Passed
   as a path parameter, the endpointId to call, see `triggers.rrp[0].endpointId`
   in the `config.json` file.
 
@@ -227,7 +227,7 @@ Request:
 ```sh
 curl -v -H 'x-api-key: 123-my-key-must-be-30-characters-min' \
 -d '{"parameters": {"coinId": "api3"}}' \
-'<httpGatewayUrl>/0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c'
+'<httpGatewayUrl>/0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6'
 ```
 
 :::

--- a/docs/airnode/v0.2/grp-providers/tutorial/config-json.md
+++ b/docs/airnode/v0.2/grp-providers/tutorial/config-json.md
@@ -45,7 +45,7 @@ The config.json file contents shown below is for the [Quick Deploy](./) demo.
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.2/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.2/reference/deployment-files/config-json.md
@@ -239,7 +239,7 @@ defined in an OIS.
 {
   "rrp": [
     {
-      "endpointId": "0xe1da7948e4dd95c04b2aaa10f4de115e67d9e109ce618750a3d8111b855a5ee5",
+      "endpointId": "0xd7ddc8ee64d6e540682ec844a5dd9737663ec3afe5751102eb4f966744751838",
       "oisTitle": "myOisTitle",
       "endpointName": "myEndpointName"
     },
@@ -252,7 +252,7 @@ In the example above, the Airnode deployment has an OIS with the title
 `myOisTitle`. This OIS has an endpoint with the name `myEndpointName`. When the
 Airnode deployment detects a [request](../../concepts/request.md) that
 references its [`airnodeAddress`](../../concepts/airnode.md#airnodeaddress) and
-`0xe1da7948e4dd95c04b2aaa10f4de115e67d9e109ce618750a3d8111b855a5ee5` as the
+`0xd7ddc8ee64d6e540682ec844a5dd9737663ec3afe5751102eb4f966744751838` as the
 [`endpointId`](../../concepts/endpoint.md#endpointid), it will call the
 specified endpoint (`myOisTitle`-`myEndpointName`) with the parameters provided
 in the request to fulfill it. See the

--- a/docs/airnode/v0.2/reference/examples/config-local.json
+++ b/docs/airnode/v0.2/reference/examples/config-local.json
@@ -34,7 +34,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353",
+        "endpointId": "0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6",
         "oisTitle": "Currency Converter API",
         "endpointName": "convertToUSD"
       }

--- a/docs/airnode/v0.2/reference/examples/config-provider.json
+++ b/docs/airnode/v0.2/reference/examples/config-provider.json
@@ -38,7 +38,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -35,7 +35,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -33,7 +33,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.3/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -32,7 +32,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.3/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.3/reference/deployment-files/config-json.md
@@ -255,7 +255,7 @@ defined in an OIS.
 {
   "rrp": [
     {
-      "endpointId": "0xe1da7948e4dd95c04b2aaa10f4de115e67d9e109ce618750a3d8111b855a5ee5",
+      "endpointId": "0xd7ddc8ee64d6e540682ec844a5dd9737663ec3afe5751102eb4f966744751838",
       "oisTitle": "myOisTitle",
       "endpointName": "myEndpointName"
     },

--- a/docs/airnode/v0.3/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.3/reference/examples/config-cloud.json
@@ -41,7 +41,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/http-gateway.md
+++ b/docs/airnode/v0.4/grp-providers/guides/build-an-airnode/http-gateway.md
@@ -55,14 +55,14 @@ on-chain and only some via the gateway, or vise versa.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -190,14 +190,14 @@ tested.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -44,14 +44,14 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -42,14 +42,14 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -202,14 +202,14 @@ tested.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.4/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -45,14 +45,14 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko Basic Request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.4/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.4/reference/deployment-files/config-json.md
@@ -343,14 +343,14 @@ defined in an OIS.
 {
   "rrp": [
     {
-      "endpointId": "0xe1da7948e4dd95c04b2aaa10f4de115e67d9e109ce618750a3d8111b855a5ee5",
+      "endpointId": "0xd7ddc8ee64d6e540682ec844a5dd9737663ec3afe5751102eb4f966744751838",
       "oisTitle": "myOisTitle",
       "endpointName": "myEndpointName"
     }
   ],
   "rrp": [
     {
-      "endpointId": "0xe1da7948e4dd95c04b2aaa10f4de115e67d9e109ce618750a3d8111b855a5ee5",
+      "endpointId": "0xd7ddc8ee64d6e540682ec844a5dd9737663ec3afe5751102eb4f966744751838",
       "oisTitle": "myOisTitle",
       "endpointName": "myEndpointName"
     }

--- a/docs/airnode/v0.4/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.4/reference/examples/config-cloud.json
@@ -50,14 +50,14 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/docs/airnode/v0.4/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.4/reference/examples/config-cloud.json
@@ -54,13 +54,6 @@
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }
-    ],
-    "http": [
-      {
-        "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
-        "oisTitle": "CoinGecko basic request",
-        "endpointName": "coinMarketData"
-      }
     ]
   },
   "ois": [

--- a/docs/airnode/v0.4/reference/examples/config-local.json
+++ b/docs/airnode/v0.4/reference/examples/config-local.json
@@ -44,7 +44,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353",
+        "endpointId": "0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6",
         "oisTitle": "Currency Converter API",
         "endpointName": "convertToUSD"
       }

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -387,21 +387,21 @@ trigger for each endpoint in your OIS object.
 "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -81,21 +81,21 @@ using the HTTP signed data gateway or via RRP.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "httpSignedData": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -174,7 +174,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -201,7 +201,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.5/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.5/reference/examples/config-cloud.json
@@ -57,21 +57,21 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }

--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -397,21 +397,21 @@ trigger for each endpoint in your OIS object.
 "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }

--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -82,21 +82,21 @@ using the HTTP signed data gateway or via RRP.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "httpSignedData": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -187,7 +187,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -198,7 +198,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.6/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.6/reference/examples/config-cloud.json
@@ -58,21 +58,21 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -270,21 +270,21 @@ trigger for each endpoint in your OIS object.
 "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -82,21 +82,21 @@ using the HTTP signed data gateway or via RRP.
 "triggers": {
   "rrp": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "http": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
   ],
   "httpSignedData": [
     {
-      "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+      "endpointId": "0x6db9e3e3d073ad12b66d28dd85bcf49f58577270b1cc2d48a43c7025f5c27af6",
       "oisTitle": "CoinGecko Basic Request",
       "endpointName": "coinMarketData",
     }
@@ -135,7 +135,7 @@ required as part of the CURL call.
 | ---------------------------------------------------------------------- | ------ | --------------------------------------------------------- |
 | Content-Type                                                           | header | `-H 'Content-Type: application/json'`                     |
 | x-api-key                                                              | header | `-H 'x-api-key: 8d890a46-799d-48b3-a337-8531e23dfe8e'`    |
-| endpointId                                                             | path   | `<gatewayUrl>/0xf466b8feec...99e9f9f90453c`               |
+| endpointId                                                             | path   | `<gatewayUrl>/0x6db9e3e3d0...c7025f5c27af6`               |
 | \* parameters<div class="tSmall">HTTP Gateway</div>                    | body   | `-d '{"parameters": {"param1": "myValue", "param2": 5}}'` |
 | \* encodedParameters<div class="tSmall">HTTP Signed Data Gateway</div> | body   | `-d '{"encodedParameters": "0x3173737300....000"}'`       |
 
@@ -160,7 +160,7 @@ curl \
 -H 'Content-Type: application/json' \
 -H 'x-api-key: 8d890a46-799d-48b3-a337-8531e23dfe8e' \
 -d '{"parameters": {"param1": "myValue", "param2": 5}}' \
-'<gatewayUrl>/0xf466b8feec...99e9f9f90453c'
+'<gatewayUrl>/0x6db9e3e3d0...c7025f5c27af6'
 ```
 
 :::
@@ -173,7 +173,7 @@ curl \
 -H 'Content-Type: application/json' \
 -H 'x-api-key: 8d890a46-799d-48b3-a337-8531e23dfe8e' \
 -d '{"encodedParameters": "0x3173737300....000"}' \
-'<gatewayUrl>/0xf466b8feec...99e9f9f90453c'
+'<gatewayUrl>/0x6db9e3e3d0...c7025f5c27af6'
 ```
 
 :::

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -187,7 +187,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -198,7 +198,7 @@ an integrated API.
 
 Looking at the [config.json](./config-json.md) code snippet below shows the HTTP
 gateway was activated for the Airnode. Furthermore the endpoint for
-`/simple/price` (with an `endpointId` of `0xf...53c`) has been added to
+`/simple/price` (with an `endpointId` of `0x6...af6`) has been added to
 `triggers.http[n]`. Only those endpoints added to the `http` array can be
 tested.
 

--- a/docs/airnode/v0.7/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.7/reference/examples/config-cloud.json
@@ -58,21 +58,21 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "http": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xf10f067e716dd8b9c91b818e3a933b880ecb3929c04a6cd234c171aa27c6eefe",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinMarketData"
       }
     ],
     "httpSignedData": [
       {
-        "endpointId": "0xaf1d557a32912da9a5170fcc54d5484b24847b150e5f3142c64111c99a689e77",
+        "endpointId": "0xd4b0718c9a3316dbd831e6d01058202e5dde20a116304419f0d79e07a82b46bf",
         "oisTitle": "CoinGecko Requests",
         "endpointName": "coinGeckoMarketData"
       }


### PR DESCRIPTION
This was basically a mass search and replace operation that required some endpoint generation. I found out that there was a quite wild mixture of IDs that were correct, those that were incorrect and mixtures of the two even within the same file. There are some endpoint IDs that I did not find oisTitles or endpointNames for, so I did not dare touch them, but otherwise I've gone through almost 600 occurrences of the endpointID variable name and fixed everything. You don't necessarily need to recheck the generated IDs; I only included reviewers to let you know this is done. I meant to create the PR late Friday afternoon but I needed to end early on a quick notice so I spent the evening cleaning up the commit and getting this ready.