### PR TITLE
Add config template docs

### DIFF
--- a/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.6/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -473,6 +473,17 @@ data.
   [derive-endpoint-id](../../../reference/packages/admin-cli.md#derive-endpoint-id)
   to derive endpoint IDs using the `oisTitle` and `endpointName`.
 
+### templates
+
+The templates field allows you to specify templates to be used to make template
+requests. The array can be left empty if no templates will be used.
+
+#### templates Reference
+
+- [templateId](../../../reference/deployment-files/config-json.md#templateid)
+- [endpointId](../../../reference/deployment-files/config-json.md#endpointid)
+- [encodedParameters](../../../reference/deployment-files/config-json.md#encodedparameters)
+
 ### ois
 
 The `ois` field is a list OIS objects that Airnode will be serving. This means

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -64,6 +64,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -60,6 +60,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -65,6 +65,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.6/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.6/reference/deployment-files/config-json.md
@@ -21,6 +21,7 @@ database of an Airnode deployment. It contains five fields as show below.
   "chains": [],
   "nodeSettings": {},
   "triggers": {},
+  "templates": [],
   "ois": [],
   "apiCredentials": []
 }
@@ -33,6 +34,7 @@ database of an Airnode deployment. It contains five fields as show below.
 - [triggers](./config-json.md#triggers): Which on-chain endpoints will be usable
   by which an available protocol (currently only RRP) and under what endpoint
   ID.
+- [templates](./config-json.md#templates):
 - [ois](./config-json.md#ois): API specifications and the corresponding on-chain
   endpoints, kept as [OIS](/ois/v1.0.0/ois.md) objects.
 - [apiCredentials](./config-json.md#apicredentials): Which API credentials will
@@ -483,6 +485,45 @@ the RRP protocol.
 #### `httpSignedData[n].endpointName`
 
 (required) - The endpoint name of an OIS endpoint.
+
+## templates
+
+An array that includes the necessary information to make
+[template requests](../../concepts/request.md#template-request)
+
+```json
+// templates
+[
+  {
+    "templateId": "0x02834eb43d56133982b7d6e5aa8b466c7ea4ba0fadf697698c1fee0996bba0fc",
+    "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
+    "encodedParameters": "0x3173000000000000000000000000000000000000000000000000000000000000636f696e49640000000000000000000000000000000000000000000000000000657468657265756d000000000000000000000000000000000000000000000000"
+  }
+]
+```
+
+### `templates`
+
+(required) - An array of templates which can be left empty if no templates are
+used. Valid templates will be used to make template requests without calling the
+contract to fetch the template from the chain. For details see:
+[using templates](../../grp-developers/using-templates.md)
+
+#### `templateId`
+
+(required) - An identifier derived by hashing the Airnode address, the
+endpointId and the encoded parameters of the template. For derivation see:
+[templates](../../concepts/template.md#templateid).
+
+#### `endpointId`
+
+(required) - An identifier derived for an oisTitle/endpointName pair. For
+derivation see:
+[derive-endpoint-id](../packages/admin-cli.md#derive-endpoint-id).
+
+#### `encodedParameters`
+
+(required) - The encoded request parameters.
 
 ## ois
 

--- a/docs/airnode/v0.6/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.6/reference/examples/config-cloud.json
@@ -78,6 +78,7 @@
       }
     ]
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.6/reference/examples/config-local.json
+++ b/docs/airnode/v0.6/reference/examples/config-local.json
@@ -54,6 +54,7 @@
       }
     ]
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.6/reference/templates/config-json.md
+++ b/docs/airnode/v0.6/reference/templates/config-json.md
@@ -117,6 +117,13 @@ building a config.json file.
       }
     ]
   },
+  "templates": [
+    {
+      "templateId": "<FILL_*>",
+      "endpointId": "<FILL_*>",
+      "encodedParameters": "<FILL_*>",
+    }
+  ],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -52,6 +52,7 @@ are five root level fields in `config.json`.
 - [chains](./configuring-airnode.md#chains)
 - [nodeSettings](./configuring-airnode.md#nodesettings)
 - [triggers](./configuring-airnode.md#triggers)
+- [templates](./configuring-airnode.md#templates)
 - [ois](./configuring-airnode.md#ois)
 - [apiCredentials](./configuring-airnode.md#apicredentials)
 
@@ -315,6 +316,17 @@ and that these endpoints can be triggers for `rrp`, `http`, and/or
   - [httpSignedData[n].endpointId](../../../reference/deployment-files/config-json.md#httpsigneddata-n-endpointid)
   - [httpSignedData[n].oisTitle](../../../reference/deployment-files/config-json.md#httpsigneddata-n-oistitle)
   - [httpSignedData[n].endpointName](../../../reference/deployment-files/config-json.md#httpsigneddata-n-endpointname)
+
+### templates
+
+The templates field allows you to specify templates to be used to make template
+requests. The array can be left empty if no templates will be used.
+
+#### templates Reference
+
+- [templateId](../../../reference/deployment-files/config-json.md#templateid)
+- [endpointId](../../../reference/deployment-files/config-json.md#endpointid)
+- [encodedParameters](../../../reference/deployment-files/config-json.md#encodedparameters)
 
 ### ois
 

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -64,6 +64,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -60,6 +60,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -65,6 +65,7 @@
     ],
     "httpSignedData": []
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -21,6 +21,7 @@ database of an Airnode deployment. It contains five fields as show below.
   "chains": [],
   "nodeSettings": {},
   "triggers": {},
+  "templates": [],
   "ois": [],
   "apiCredentials": []
 }
@@ -33,6 +34,7 @@ database of an Airnode deployment. It contains five fields as show below.
 - [triggers](./config-json.md#triggers): Which on-chain endpoints will be usable
   by which an available protocol (currently only RRP) and under what endpoint
   ID.
+- [templates](./config-json.md#templates):
 - [ois](./config-json.md#ois): API specifications and the corresponding on-chain
   endpoints, kept as [OIS](/ois/v1.0.0/ois.md) objects.
 - [apiCredentials](./config-json.md#apicredentials): Which API credentials will
@@ -536,6 +538,45 @@ the HTTP Signed Data Gateway.
 #### `httpSignedData[n].endpointName`
 
 (required) - The endpoint name of an OIS endpoint.
+
+## templates
+
+An array that includes the necessary information to make
+[template requests](../../concepts/request.md#template-request)
+
+```json
+// templates
+[
+  {
+    "templateId": "0x02834eb43d56133982b7d6e5aa8b466c7ea4ba0fadf697698c1fee0996bba0fc",
+    "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
+    "encodedParameters": "0x3173000000000000000000000000000000000000000000000000000000000000636f696e49640000000000000000000000000000000000000000000000000000657468657265756d000000000000000000000000000000000000000000000000"
+  }
+]
+```
+
+### `templates`
+
+(required) - An array of templates which can be left empty if no templates are
+used. Valid templates will be used to make template requests without calling the
+contract to fetch the template from the chain. For details see:
+[using templates](../../grp-developers/using-templates.md)
+
+#### `templateId`
+
+(required) - An identifier derived by hashing the Airnode address, the
+endpointId and the encoded parameters of the template. For derivation see:
+[templates](../../concepts/template.md#templateid).
+
+#### `endpointId`
+
+(required) - An identifier derived for an oisTitle/endpointName pair. For
+derivation see:
+[derive-endpoint-id](../packages/admin-cli.md#derive-endpoint-id).
+
+#### `encodedParameters`
+
+(required) - The encoded request parameters.
 
 ## ois
 

--- a/docs/airnode/v0.7/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.7/reference/examples/config-cloud.json
@@ -78,6 +78,7 @@
       }
     ]
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/reference/examples/config-local.json
+++ b/docs/airnode/v0.7/reference/examples/config-local.json
@@ -54,6 +54,7 @@
       }
     ]
   },
+  "templates": [],
   "ois": [
     {
       "oisFormat": "1.0.0",

--- a/docs/airnode/v0.7/reference/templates/config-json.md
+++ b/docs/airnode/v0.7/reference/templates/config-json.md
@@ -117,6 +117,13 @@ building a config.json file.
       }
     ]
   },
+  "templates": [
+    {
+      "templateId": "<FILL_*>",
+      "endpointId": "<FILL_*>",
+      "encodedParameters": "<FILL_*>",
+    }
+  ],
   "ois": [
     {
       "oisFormat": "1.0.0",


### PR DESCRIPTION
This adds documentation for the new `templates` field in `config.json` which allows hardcoded templates (V0/RRP only) to be used by the Airnode.