### PR TITLE
Remove new networks field from component data

### DIFF
--- a/docs/.vuepress/components/airnode/ContractAddresses.vue
+++ b/docs/.vuepress/components/airnode/ContractAddresses.vue
@@ -125,6 +125,9 @@ export default {
         // Pull the chainNames from resp
         this.buildChainsObj(response.data.chainNames);
         delete response.data['chainNames'];
+        // Jun 2022, networks was add to the payload, not needed.
+        // See GitHub issue 833
+        delete response.data['networks'];
 
         // Create a list of contracts with addresses
         for (const key in response.data) {


### PR DESCRIPTION
A new filed was added to the operations repo in hte `references.json` file named `'networks'. This component saw it as a contract rather than a reference to chains.

Closing #833