### PR TITLE
Add doc set for /operations

### DIFF
--- a/docs/.vuepress/components/DocumentSets.vue
+++ b/docs/.vuepress/components/DocumentSets.vue
@@ -1,13 +1,17 @@
 <!--
 This component places document sets in the header of the sidebar. 
 
-NOTE: When this component is MOUNTED (as it is mounted from a landing page click),
+NOTE: When this component is MOUNTED (as it is mounted from a landing page click
+or an SPA load/reload),
 it will always default to the startPath in config.json.
 -->
 
 <template>
   <div>
-    <div style="padding-left: 12px; margin-top: -4px" v-if="isMounted">
+    <div
+      style="padding-left: 12px; margin-top: -4px"
+      v-show="isMounted && !hidePickList"
+    >
       <!-- Current Route -->
       <div class="list-line">
         <div
@@ -131,14 +135,25 @@ export default {
     ],
     env: env,
     showDocSets: false,
+    hidePickList: false, // Hiding pick list when route path is /dev or /operations
     isMounted: false, // When the page is mounted show icons to avoid flickering
   }),
   watch: {
     $route(event) {
+      this.unpublishedDocSet();
       this.selectIcon(event.path);
     },
   },
   methods: {
+    /**
+     * Checks if the doc set is not published in the pick list.
+     * /operations and /dev
+     */
+    unpublishedDocSet() {
+      const paths = ['/operations', '/dev'];
+      const pathArr = this.$route.path.split('/');
+      this.hidePickList = paths.includes('/' + pathArr[1]);
+    },
     selectIcon(path) {
       // Close the mobile list
       this.showDocSets = false;
@@ -209,7 +224,7 @@ export default {
     this.$nextTick(function () {
       // TEMP removed dAPIs for now
       this.docSets.splice(4, 1); // Removes dAPIs
-
+      this.unpublishedDocSet();
       this.selectIcon(this.$route.path);
       this.isMounted = true;
     });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -73,6 +73,7 @@ module.exports = {
       '/dao-members/': require(`../dao-members/sidebar.js`),
       '/api3/': require(`../api3/sidebar.js`),
       '/dev/': require(`../dev/sidebar.js`),
+      '/operations/': require(`../operations/sidebar.js`),
     },
     /*
       2021-02-17: wkande:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,11 @@
+---
+title: Overview
+folder: Operations
+---
+
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
+
+# {{$frontmatter.title}}
+
+<TocHeader />
+<TOC class="table-of-contents" :include-level="[2,3]" />

--- a/docs/operations/another-folder/stuff.md
+++ b/docs/operations/another-folder/stuff.md
@@ -1,0 +1,11 @@
+---
+title: Some Stuff
+folder: Another Folder
+---
+
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
+
+# {{$frontmatter.title}}
+
+<TocHeader />
+<TOC class="table-of-contents" :include-level="[2,3]" />

--- a/docs/operations/sidebar.js
+++ b/docs/operations/sidebar.js
@@ -1,0 +1,12 @@
+module.exports = [
+  {
+    title: 'Operations',
+    collapsable: false,
+    children: ['/operations/'],
+  },
+  {
+    title: 'Another Folder',
+    collapsable: false,
+    children: ['/operations/another-folder/stuff.md'],
+  },
+];


### PR DESCRIPTION
Closes #885 
@aquarat @kolenic-martin 

There is now an `/operations` path in the docs. This opens up a new **Operations docs set**. The doc set will not be loaded into the doc set pick list which is normally presented at the top of the sidebar. In addition, the pick list is hidden when the url contains `/operations`. This is the same behavior as `/dev`. 

The doc set is public and can be discovered but this could be made private if needed I suppose.

Please check out the **[preview site here](https://api3-docs--885-operations-doc-set-04pozze3.web.app/operations/)**.
