### PR TITLE
Split deployer remove command in two and output receipt.json to config/

### DIFF
--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -94,7 +94,7 @@ docker run -it --rm \
   --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -107,7 +107,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -125,7 +125,7 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -136,7 +136,7 @@ docker run -it --rm \
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -159,7 +159,7 @@ directory, is used to remove the Airnode.
 docker run -it --rm \
   --env-file aws.env \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -172,7 +172,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -189,7 +189,7 @@ docker run -it --rm ^
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -202,7 +202,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -18,14 +18,9 @@ build the images yourself see the
 [README](https://github.com/api3dao/airnode/tree/v0.7/packages/airnode-deployer/docker)
 in the deployer package.
 
-The deployer image has two commands.
-
-- `deploy`: Deploys or updates an Airnode using configuration files.
-- `remove`: Removes an Airnode using its `receipt.json` file.
-
 ::: tip Quick Deploy Demos
 
-See the [Quick Deploy Demos](../tutorial/) to quickly `deploy` and `remove` a
+See the [Quick Deploy Demos](../tutorial/) to quickly deploy and remove a
 preconfigured Airnode using the deployer image.
 
 :::
@@ -41,9 +36,8 @@ my-airnode
 ├── aws.env     <- Used for AWS deployment
 ├── gcp.json    <- Used for GCP deployment
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 ## Cloud Provider Credentials
@@ -100,7 +94,6 @@ docker run -it --rm \
   --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -114,7 +107,6 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -133,7 +125,6 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -145,7 +136,6 @@ docker run -it --rm \
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -153,10 +143,11 @@ docker run -it --rm ^
 
 ::::
 
-## remove
+## remove-with-receipt
 
-When an Airnode was deployed using the `deploy` command a `receipt.json` file
-was created. Use this file to remove an Airnode.
+When an Airnode was deployed using the `deploy` command, a `receipt.json` file
+was created. This file, which is by default expected to be in the `config/`
+directory, is used to remove the Airnode.
 
 ### AWS
 
@@ -167,8 +158,8 @@ was created. Use this file to remove an Airnode.
 ```sh
 docker run -it --rm \
   --env-file aws.env \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -180,8 +171,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   --env-file aws.env ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -197,8 +188,8 @@ docker run -it --rm ^
 ```sh
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -210,8 +201,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -221,8 +212,8 @@ docker run -it --rm ^
 ## Manual Removal
 
 Optionally you can remove an Airnode manually though it is highly recommended
-that you do so using the deployer image's `remove` command. Airnode has a
-presence in several areas of both AWS and GCP. An Airnode has a
+that you do so using the deployer image's `remove-with-receipt` command. Airnode
+has a presence in several areas of both AWS and GCP. An Airnode has a
 `airnodeAddressShort` (e.g., `0ab830c`) that is included in the element name of
 AWS and GCP deployed features.
 

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/README.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/README.md
@@ -23,19 +23,17 @@ for GCP deployments when encountered.
 
 ## Project Folder
 
-Create a folder called `/my-airnode` with two more internal folders named
-`/config` and `/output`. Add the files `config.json`, `secrets.env`, and
-`aws.env` as shown below. Optionally add `gcp.json` if you intend to deploy to
-GCP as well.
+Create a folder called `/my-airnode` with one more internal folder named
+`/config`. Add the files `config.json`, `secrets.env`, and `aws.env` as shown
+below. Optionally add `gcp.json` if you intend to deploy to GCP as well.
 
 ```
 my-airnode
 ├── aws.env     <- For AWS deployment
 ├── gcp.json    <- Optional for GCP deployment
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 This guide will explain the content of the configuration files and run the

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -65,9 +65,8 @@ but not used by the deployer image.
 my-airnode
 ├── aws.env
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 :::
@@ -78,9 +77,8 @@ my-airnode
 my-airnode
 ├── gcp.json
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 :::
@@ -90,7 +88,7 @@ my-airnode
 From the root of the project directory run the Docker
 [deployer image](../../docker/deployer-image.md) which will deploy the Airnode.
 When the deployment has completed a `receipt.json` file will be written to the
-`/output` folder. This file contains important configuration information about
+`/config` folder. This file contains important configuration information about
 the Airnode and is needed to remove the Airnode should the need arise.
 
 <!-- Use of .html below is intended. -->
@@ -109,7 +107,6 @@ docker run -it --rm \
   --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -123,7 +120,6 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -142,7 +138,6 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -156,7 +151,6 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -165,7 +159,7 @@ docker run -it --rm ^
 ::::
 
 When the deployment is complete a `receipt.json` file is placed into the
-`/output` folder.
+`/config` folder.
 
 ### receipt.json
 
@@ -210,8 +204,9 @@ that detail how to do this.
 
 ## Removing the Airnode
 
-When the Airnode was deployed a `receipt.json` file was created in the `/output`
-folder. This file is needed to remove an Airnode.
+When an Airnode was deployed using the `deploy` command, a `receipt.json` file
+was created. This file, which is by default expected to be in the `config/`
+directory, is used to remove the Airnode.
 
 ### AWS
 
@@ -222,8 +217,8 @@ folder. This file is needed to remove an Airnode.
 ```sh
 docker run -it --rm \
   --env-file aws.env \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -235,8 +230,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   --env-file aws.env ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -252,8 +247,8 @@ docker run -it --rm ^
 ```sh
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -265,8 +260,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -107,7 +107,7 @@ docker run -it --rm \
   --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -120,7 +120,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -138,7 +138,7 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -151,7 +151,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -182,7 +182,7 @@ deployment was successful or not.
       "region": "us-east-1"
     },
     "stage": "dev",
-    "nodeVersion": "0.7.2",
+    "nodeVersion": "0.8.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "api": {
@@ -218,7 +218,7 @@ directory, is used to remove the Airnode.
 docker run -it --rm \
   --env-file aws.env \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -231,7 +231,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -248,7 +248,7 @@ docker run -it --rm ^
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -261,7 +261,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -50,8 +50,8 @@ a zip file ready to go.
 
 ::: tab Create Manually
 
-Create a folder called `/quick-deploy-aws` with two more internal folders named
-`/config` and `/output`. Place the contents of the files provided
+Create a folder called `/quick-deploy-aws` with one more internal folder named
+`/config`. Place the contents of the files provided
 ([config.json](./config-json.md), [secrets.env](./secrets-env.md) and
 [aws.env](./aws-env.md)) into the locations show below.
 
@@ -59,9 +59,8 @@ Create a folder called `/quick-deploy-aws` with two more internal folders named
 quick-deploy-aws
 ├── aws.env
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 :::
@@ -79,7 +78,7 @@ quick-deploy-aws</a> project folder.
 
 Prepare the three configuration files. By default, the Airnode deployer image
 looks for `config.json` and `secrets.env` in `/config`, for `aws.env` in the
-project root and writes `receipt.json` to the `/output` folder.
+project root and writes `receipt.json` to the `/config` folder.
 
 ### config.json
 
@@ -154,8 +153,7 @@ docker run -it --rm \
   --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -168,8 +166,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -303,9 +300,10 @@ curl -v ^
 
 ## Remove the Airnode
 
-When you are done with this demo you can remove it. When the Airnode was
-deployed a `receipt.json` file was created in the `/output` folder. This file is
-needed to remove an Airnode.
+When you are done with this demo you can remove it. When an Airnode was deployed
+using the `deploy` command, a `receipt.json` file was created. This file, which
+is by default expected to be in the `config/` directory, is used to remove the
+Airnode.
 
 - `--env-file`: Location of the `aws.env` file.
 - `-v`: Location of the `receipt.json` file.
@@ -317,8 +315,8 @@ needed to remove an Airnode.
 ```sh
 docker run -it --rm \
   --env-file aws.env \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -330,8 +328,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   --env-file aws.env ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -52,17 +52,16 @@ a zip file ready to go.
 
 ::: tab Create Manually
 
-Create a folder called `/quick-deploy-gcp` with two more internal folders named
-`/config` and `/output`. Place the contents of the files provided
+Create a folder called `/quick-deploy-gcp` with one more internal folder named
+`/config`. Place the contents of the files provided
 ([config.json](./config-json.md) and [secrets.env](./secrets-env.md)) into the
 locations show below.
 
 ```
 quick-deploy-gcp
 ├── config
-│   ├── config.json
-│   └── secrets.env
-└── output
+    ├── config.json
+    └── secrets.env
 ```
 
 :::
@@ -80,7 +79,7 @@ quick-deploy-gcp</a> project folder.
 
 Prepare the configuration files, setup a GCP project and obtain credentials. By
 default, the Airnode deployer image looks for `config.json` and `secrets.env` in
-`/config` and writes `receipt.json` to the `/output` folder.
+`/config` and writes `receipt.json` to the `/config` folder.
 
 ### config.json
 
@@ -165,7 +164,6 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -179,7 +177,6 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
 ```
 
@@ -315,7 +312,7 @@ curl -v ^
 ## Remove the Airnode
 
 When you are done with this demo you can remove it. When the Airnode was
-deployed a `receipt.json` file was created in the `/output` folder. This file is
+deployed a `receipt.json` file was created in the `/config` folder. This file is
 needed to remove an Airnode.
 
 :::: tabs
@@ -325,8 +322,8 @@ needed to remove an Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
-  -v "$(pwd)/output:/app/output" \
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::
@@ -338,8 +335,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
-  -v "%cd%/output:/app/output" ^
-  api3/airnode-deployer:0.7.2 remove -r output/receipt.json
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.7.2 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -164,7 +164,7 @@ docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -177,7 +177,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 deploy
+  api3/airnode-deployer:0.8.0 deploy
 ```
 
 :::
@@ -323,7 +323,7 @@ needed to remove an Airnode.
 docker run -it --rm \
   -v "$(pwd)/gcp.json:/app/gcp.json" \
   -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::
@@ -336,7 +336,7 @@ For Windows, use CMD (and not PowerShell).
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.7.2 remove-with-receipt
+  api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
 
 :::

--- a/docs/airnode/v0.8/reference/deployment-files/receipt-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/receipt-json.md
@@ -48,7 +48,7 @@ not generated for client deployments (deploying to a Docker container).
       "disableConcurrencyReservations": false
     },
     "stage": "starter-example",
-    "nodeVersion": "0.7.2",
+    "nodeVersion": "0.8.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "api": {
@@ -78,7 +78,7 @@ not generated for client deployments (deploying to a Docker container).
       "projectId": "api3-753118"
     },
     "stage": "dev",
-    "nodeVersion": "0.7.2",
+    "nodeVersion": "0.8.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "api": {},

--- a/docs/airnode/v0.8/reference/deployment-files/receipt-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/receipt-json.md
@@ -11,9 +11,8 @@ folder: Reference > Deployment Files
 
 A `receipt.json` file is outputted after each deployment and contains
 non-sensitive information about the deployment. The main use of a receipt file
-is to remove an Airnode deployment when no longer needed. Use the
-[docker image](../../grp-providers/docker/deployer-image.md#remove) to execute
-the remove command.
+is to remove an Airnode deployment when no longer needed. See the
+[Airnode Removal documentation](../packages/deployer.md) for usage and commands.
 
 It also provides the Airnode xpub for the hardened derivation path
 `m/44'/60'/0'` that must be announced off-chain in order for sponsors to derive

--- a/docs/airnode/v0.8/reference/packages/deployer.md
+++ b/docs/airnode/v0.8/reference/packages/deployer.md
@@ -45,7 +45,7 @@ you to run deployer commands without installing the deployer npm package or
 having to manually build the airnode-deployer package yourself.
 
 ```sh
-npx @api3/airnode-deployer deploy --config pathTo/config.json --secrets pathTo/secrets.env --receipt myOutput/receipt.json
+npx @api3/airnode-deployer deploy --config config/config.json --secrets config/secrets.env --receipt config/receipt.json
 ```
 
 ### Global Package
@@ -59,7 +59,7 @@ yarn global add @api3/airnode-deployer
 npm install @api3/airnode-deployer -g
 
 # Executing the deployer.
-airnode-deployer deploy --config pathTo/config.json --secrets pathTo/secrets.env --receipt myOutput/receipt.json
+airnode-deployer deploy --config config/config.json --secrets config/secrets.env --receipt config/receipt.json
 ```
 
 <!--  HOLD THIS UNTIL THE REPO README IS UPDATED
@@ -108,26 +108,9 @@ cp config/secrets.env.example config/secrets.env
 ```
 -->
 
-## Examples
+## Commands
 
-The deployer has two commands. To re-deploy an existing Airnode run the `deploy`
-command again.
-
-- [deploy](./deployer.md#deploy)
-- [remove](./deployer.md#remove)
-
-### Workflows
-
-1. Make sure you have `config.json` and `secrets.env` ready. Then, use the
-   `deploy` command to trigger your first deployment.
-2. In order to update the Airnode configuration:
-   - Update the `config.json` and `secrets.env` files as needed.
-   - Run the `deploy` command again.
-3. Use the `remove` command to remove the Airnode deployment. Use the `-r`
-   option to provide the receipt file from the latest deployment or manually add
-   the required arguments.
-
-### deploy
+### Airnode Deployment
 
 When creating or updating an Airnode the `config.json` and `secrets.env` files
 are needed. You can use the provided example
@@ -143,9 +126,12 @@ API details and secrets.
 Make sure `config.json` and `secrets.env` are available in the path for the
 `--configuration` argument.
 
-When completed the `deploy` command creates a receipt using the path and name
-from the `--receipt` argument. The receipt contains metadata about the
-deployment and can be used to remove the Airnode.
+#### deploy
+
+When executed, the `deploy` command defaults to creating a `receipt.json` file
+in the `config/` directory, although a different path can be specified using the
+path and name with the `--receipt` argument. The receipt contains metadata about
+the deployment and can be used to remove the Airnode.
 
 If the deployment isn't successful, the command will try to automatically remove
 deployed resources. You can disable this by running the deploy command with a
@@ -161,28 +147,34 @@ Options:
       --help                             Show help                                                             [boolean]
   -c, --configuration, --config, --conf  Path to configuration file             [string] [default: "config/config.json"]
   -s, --secrets                          Path to secrets file                   [string] [default: "config/secrets.env"]
-  -r, --receipt                          Output path for receipt file          [string] [default: "output/receipt.json"]
+  -r, --receipt                          Output path for receipt file          [string] [default: "config/receipt.json"]
       --auto-remove                      Enable automatic removal of deployed resources for failed deployments
                                                                                                [boolean] [default: true]
 
-# Example
-airnode-deployer deploy --config pathTo/config.json --secrets pathTo/secrets.env --receipt myOutput/receipt.json
+# Basic example
+airnode-deployer deploy
+
+# Advanced example
+airnode-deployer deploy --config config/config.json --secrets config/secrets.env --receipt config/receipt.json
 ```
 
-### remove
+### Airnode Removal
 
-An Airnode can be removed using the remove command two different ways.
+An Airnode can be removed in two different ways:
 
-- **Best:** With a deployment receipt created when the Airnode was deployed.
-- **Alternate:** With the Airnode short address and cloud provider
-  specifications. The `airnodeShortAddress` is used in the cloud console within
-  the names of the serverless functions. The other values can be found in
-  `config.json`.
+- **Best:** With `remove-with-receipt`, which uses the deployment receipt
+  created when the Airnode was deployed.
+- **Alternate:** With `remove-with-deployment-details`, which uses the Airnode
+  short address and cloud provider specifications. The `airnodeShortAddress` is
+  used in the cloud console within the names of the serverless functions. The
+  other values can be found in `config.json`.
   - `nodeSetting.cloudProvider.type`
   - `nodeSetting.cloudProvider.region`
   - <code style="overflow-wrap: break-word;">nodeSetting.cloudProvider.projectId</code>
     (GCP only)
   - `nodeSetting.stage`
+
+#### remove-with-receipt
 
 ```bash
 # Removes a deployed Airnode instance.
@@ -191,14 +183,30 @@ Options:
       --version                Show version number                                                             [boolean]
       --debug                  Run in debug mode                                              [boolean] [default: false]
       --help                   Show help                                                                       [boolean]
-  -r, --receipt                Path to receipt file                                                             [string]
+  -r, --receipt                Path to receipt file                            [string] [default: "config/receipt.json"]
+
+# Basic example
+airnode-deployer remove-with-receipt
+
+# Advanced example specifying the receipt file location
+airnode-deployer remove-with-receipt --receipt config/receipt.json
+```
+
+#### remove-with-deployment-details
+
+```bash
+# Removes a deployed Airnode instance.
+
+Options:
+      --version                Show version number                                                             [boolean]
+      --debug                  Run in debug mode                                              [boolean] [default: false]
+      --help                   Show help                                                                       [boolean]
   -a, --airnode-address-short  Airnode Address (short version)                                                  [string]
   -s, --stage                  Stage (environment)                                                              [string]
   -c, --cloud-provider         Cloud provider                                                    [choices: "aws", "gcp"]
   -e, --region                 Region                                                                           [string]
   -p, --project-id             Project ID (GCP only)                                                            [string]
 
-# Examples
-airnode-deployer remove --receipt myOutput/receipt.json
-airnode-deployer remove --airnode-address-short abd9eaa --stage dev --cloud-provider aws --region us-east-1
+# Example
+airnode-deployer remove-with-deployment-details --airnode-address-short abd9eaa --stage dev --cloud-provider aws --region us-east-1
 ```

--- a/docs/airnode/v0.8/reference/packages/deployer.md
+++ b/docs/airnode/v0.8/reference/packages/deployer.md
@@ -10,7 +10,7 @@ folder: Reference > Packages
 <VersionWarning/>
 
 <TocHeader />
-<TOC class="table-of-contents" :include-level="[2,3]" />
+<TOC class="table-of-contents" :include-level="[2,4]" />
 
 The
 [airnode-deployer](https://github.com/api3dao/airnode/tree/v0.7/packages/airnode-deployer)


### PR DESCRIPTION
Documentation for api3dao/airnode#1322.

Rather than one clunky `remove` command, there are now two remove commands.  `remove-with-receipt` (preferred) uses `receipt.json` while `remove-with-deployment-details` expects the various deployment details instead.

The `receipt.json` default output folder is now `config/` rather than `output/` and therefore all references to the `output/` configuration directory have been removed or replaced, including in the `deploy` command. 

Closes #855 