### PR TITLE
Update aws.env file handling instructions and docker commands

### DIFF
--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -97,8 +97,8 @@ deployment information and is used to remove the Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -112,7 +112,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -166,7 +166,7 @@ was created. Use this file to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -179,7 +179,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -158,7 +158,6 @@ directory, is used to remove the Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -172,7 +171,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -466,7 +466,6 @@ in the `aws.env` file as shown below. See an
 [example file](../../../reference/templates/aws-env.md) in the reference
 section.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```bash

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -106,8 +106,8 @@ the Airnode and is needed to remove the Airnode should the need arise.
 
 ```
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -121,7 +121,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -221,7 +221,7 @@ folder. This file is needed to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -234,7 +234,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -217,7 +217,6 @@ directory, is used to remove the Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -231,7 +230,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -151,8 +151,8 @@ Run the following command to deploy the demo Airnode. Note that the version of
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -166,7 +166,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -307,7 +307,7 @@ When you are done with this demo you can remove it. When the Airnode was
 deployed a `receipt.json` file was created in the `/output` folder. This file is
 needed to remove an Airnode.
 
-- `--env-file`: Location of the `aws.env` file.
+- `-v`: Location of the `aws.env` file.
 - `-v`: Location of the `receipt.json` file.
 
 :::: tabs
@@ -316,7 +316,7 @@ needed to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -329,7 +329,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -315,7 +315,6 @@ Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -329,7 +328,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/reference/deployment-files/aws-env.md
+++ b/docs/airnode/v0.8/reference/deployment-files/aws-env.md
@@ -13,7 +13,6 @@ When it is time to deploy the Airnode to AWS, the Docker
 [deployer image](../../grp-providers/docker/deployer-image.md) will need the AWS
 credentials to build the node.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```bash

--- a/docs/airnode/v0.8/reference/examples/aws-env.md
+++ b/docs/airnode/v0.8/reference/examples/aws-env.md
@@ -9,7 +9,6 @@ folder: Reference > Example Files
 
 <VersionWarning/>
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```sh

--- a/docs/airnode/v0.8/reference/templates/aws-env.md
+++ b/docs/airnode/v0.8/reference/templates/aws-env.md
@@ -15,7 +15,6 @@ used by the Docker
 Airnode to AWS. For more details, see the full description of the
 [aws.env](../deployment-files/aws-env.md) file.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```sh


### PR DESCRIPTION
This updates the `aws.env` credentials to be mounted into the docker image as a file (and then exported from there by the deployer) instead of being read directly by docker into the container. env variables This allows the `aws.env` file to contain double quotes.