### PR TITLE
Remove duplication in deployment instructions

### DIFF
--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -97,8 +97,8 @@ deployment information and is used to remove the Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -112,7 +112,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -166,7 +166,7 @@ was created. Use this file to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -179,7 +179,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -46,26 +46,14 @@ In order to deploy Airnode to a serverless cloud provider, you need to provide
 could provider credentials to the Airnode deployer image. The deployer image
 currently supports deploying to AWS and GCP.
 
-### AWS
+For AWS deployment, see the
+[AWS Setup](../guides/build-an-airnode/configuring-airnode.md#aws-setup-aws-deployment-only)
+and for GCP deployment, see the
+[GCP Setup](../guides/build-an-airnode/configuring-airnode.md#gcp-setup-gcp-deployment-only).
 
-If you are new to AWS watch this
-[video](https://www.youtube.com/watch?v=KngM5bfpttA) to set up an AWS account
-and create cloud provider credentials.
+## Airnode Deployment
 
-### GCP
-
-- Create a
-  [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
-- Enable
-  [App Engine Admin API](https://console.cloud.google.com/apis/library/appengine.googleapis.com)
-  for your project
-- Create a new
-  [service account](https://console.cloud.google.com/iam-admin/serviceaccounts)
-  with the `Owner` role
-- Add a new access key of type JSON for the service account and download it as
-  `gcp.json`
-
-## deploy
+### deploy
 
 The `deploy` command will create the Airnode with a cloud provider or update it
 if it already exists. Three files are needed to run the deploy command.
@@ -75,7 +63,12 @@ if it already exists. Three files are needed to run the deploy command.
 - aws.env (AWS only)
 - gcp.json (GCP only)
 
-A `receipt.json` file will be created upon completion. It contains some
+See
+[Deploying an Airnode](../guides/build-an-airnode/deploying-airnode.md#deploy-with-docker)
+for deployment commands specific to various operating systems and cloud
+providers.
+
+Note a `receipt.json` file will be created upon completion. It contains some
 deployment information and is used to remove the Airnode.
 
 <!-- Use of .html below is intended. -->
@@ -83,73 +76,16 @@ deployment information and is used to remove the Airnode.
 
 <p><airnode-DeployerPermissionsWarning/></p>
 
-### AWS
+## Airnode Removal
 
-:::: tabs
-
-::: tab Linux/Mac/WSL2
-
-```sh
-docker run -it --rm \
-  -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
-  -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.8.0 deploy
-```
-
-:::
-
-::: tab Windows
-
-For Windows, use CMD (and not PowerShell).
-
-```sh
-docker run -it --rm ^
-  -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.8.0 deploy
-```
-
-:::
-
-::::
-
-### GCP
-
-:::: tabs
-
-::: tab Linux/Mac/WSL2
-
-```sh
-docker run -it --rm \
-  -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
-  -v "$(pwd)/gcp.json:/app/gcp.json" \
-  -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.8.0 deploy
-```
-
-:::
-
-::: tab Windows
-
-```sh
-docker run -it --rm ^
-  -v "%cd%/gcp.json:/app/gcp.json" ^
-  -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.8.0 deploy
-```
-
-:::
-
-::::
-
-## remove-with-receipt
+### remove-with-receipt
 
 When an Airnode was deployed using the `deploy` command, a `receipt.json` file
 was created. This file, which is by default expected to be in the `config/`
-directory, is used to remove the Airnode.
+directory, is used to remove the Airnode. The `remove-with-receipt` command is
+the recommended way to remove a deployment.
 
-### AWS
+#### AWS
 
 :::: tabs
 
@@ -179,7 +115,7 @@ docker run -it --rm ^
 
 ::::
 
-### GCP
+#### GCP
 
 :::: tabs
 
@@ -209,13 +145,90 @@ docker run -it --rm ^
 
 ::::
 
-## Manual Removal
+### remove-with-deployment-details
+
+- The `remove-with-deployment-details` command is available as an alternative to
+  `remove-with-receipt` and uses the Airnode short address and cloud provider
+  specifications. The `airnodeShortAddress` is used in the cloud console within
+  the names of the serverless functions. The other values can be found in
+  `config.json`.
+  - `nodeSetting.cloudProvider.type`
+  - `nodeSetting.cloudProvider.region`
+  - <code style="overflow-wrap: break-word;">nodeSetting.cloudProvider.projectId</code>
+    (GCP only)
+  - `nodeSetting.stage`
+
+Note that the example commands below use placeholder values that should be
+replaced.
+
+#### AWS
+
+:::: tabs
+
+::: tab Linux/Mac/WSL2
+
+```sh
+docker run -it --rm \
+  -v "$(pwd)/aws.env:/app/aws.env" \
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.8.0 remove-with-deployment-details --airnode-address-short abd9eaa --stage dev --cloud-provider aws --region us-east-1
+```
+
+:::
+
+::: tab Windows
+
+For Windows, use CMD (and not PowerShell).
+
+```sh
+docker run -it --rm ^
+  -v "%cd%/aws.env:/app/aws.env" ^
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.8.0 remove-with-deployment-details --airnode-address-short abd9eaa --stage dev --cloud-provider aws --region us-east-1
+```
+
+:::
+
+::::
+
+#### GCP
+
+:::: tabs
+
+::: tab Linux/Mac/WSL2
+
+```sh
+docker run -it --rm \
+  -v "$(pwd)/gcp.json:/app/gcp.json" \
+  -v "$(pwd)/config:/app/config" \
+  api3/airnode-deployer:0.8.0 remove-with-deployment-details --airnode-address-short abd9eaa --stage dev --cloud-provider gcp --region us-east1
+```
+
+:::
+
+::: tab Windows
+
+For Windows, use CMD (and not PowerShell).
+
+```sh
+docker run -it --rm ^
+  -v "%cd%/gcp.json:/app/gcp.json" ^
+  -v "%cd%/config:/app/config" ^
+  api3/airnode-deployer:0.8.0 remove-with-deployment-details --airnode-address-short abd9eaa --stage dev --cloud-provider gcp --region us-east1
+```
+
+:::
+
+::::
+
+### Manual Removal
 
 Optionally you can remove an Airnode manually though it is highly recommended
-that you do so using the deployer image's `remove-with-receipt` command. Airnode
-has a presence in several areas of both AWS and GCP. An Airnode has a
-`airnodeAddressShort` (e.g., `0ab830c`) that is included in the element name of
-AWS and GCP deployed features.
+that you do so using the deployer image's `remove-with-receipt` or
+`remove-with-deployment-details` commands. Airnode has a presence in several
+areas of both AWS and GCP. An Airnode has a `airnodeAddressShort` (e.g.,
+`0ab830c`) that is included in the element name of AWS and GCP deployed
+features.
 
 ::: danger Remember
 

--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -158,7 +158,6 @@ directory, is used to remove the Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -172,7 +171,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -466,7 +466,6 @@ in the `aws.env` file as shown below. See an
 [example file](../../../reference/templates/aws-env.md) in the reference
 section.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```bash

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -106,8 +106,8 @@ the Airnode and is needed to remove the Airnode should the need arise.
 
 ```
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -121,7 +121,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -221,7 +221,7 @@ folder. This file is needed to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -234,7 +234,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -102,7 +102,7 @@ the Airnode and is needed to remove the Airnode should the need arise.
 
 ::: tab Linux/Mac/WSL2
 
-```
+```sh
 docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd)/aws.env:/app/aws.env" \
@@ -202,74 +202,13 @@ that detail how to do this.
 - [Quick Deploy AWS](../../tutorial/quick-deploy-aws/#test-the-airnode)
 - [Quick Deploy GCP](../../tutorial/quick-deploy-gcp/#test-the-airnode)
 
-## Removing the Airnode
-
-When an Airnode was deployed using the `deploy` command, a `receipt.json` file
-was created. This file, which is by default expected to be in the `config/`
-directory, is used to remove the Airnode.
-
-### AWS
-
-:::: tabs
-
-::: tab Linux/Mac/WSL2
-
-```sh
-docker run -it --rm \
-  -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.8.0 remove-with-receipt
-```
-
-:::
-
-::: tab Windows
-
-For Windows, use CMD (and not PowerShell).
-
-```sh
-docker run -it --rm ^
-  -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.8.0 remove-with-receipt
-```
-
-:::
-
-::::
-
-### GCP
-
-:::: tabs
-
-::: tab Linux/Mac/WSL2
-
-```sh
-docker run -it --rm \
-  -v "$(pwd)/gcp.json:/app/gcp.json" \
-  -v "$(pwd)/config:/app/config" \
-  api3/airnode-deployer:0.8.0 remove-with-receipt
-```
-
-:::
-
-::: tab Windows
-
-For Windows, use CMD (and not PowerShell).
-
-```sh
-docker run -it --rm ^
-  -v "%cd%/gcp.json:/app/gcp.json" ^
-  -v "%cd%/config:/app/config" ^
-  api3/airnode-deployer:0.8.0 remove-with-receipt
-```
-
-:::
-
-::::
-
 ## Calling the Airnode
 
 Once the Airnode is deployed, see
 [Calling an Airnode](../../../grp-developers/call-an-airnode.md) to learn how
 requests are made to it.
+
+## Removing the Airnode
+
+If you would like to remove a deployed Airnode, see the
+[Airnode Removal](../../docker/deployer-image.md#airnode-removal) instructions.

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -217,7 +217,6 @@ directory, is used to remove the Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -231,7 +230,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -151,8 +151,8 @@ Run the following command to deploy the demo Airnode. Note that the version of
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 deploy
@@ -166,7 +166,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/config:/app/config" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 deploy
@@ -307,7 +307,7 @@ When you are done with this demo you can remove it. When the Airnode was
 deployed a `receipt.json` file was created in the `/output` folder. This file is
 needed to remove an Airnode.
 
-- `--env-file`: Location of the `aws.env` file.
+- `-v`: Location of the `aws.env` file.
 - `-v`: Location of the `receipt.json` file.
 
 :::: tabs
@@ -316,7 +316,7 @@ needed to remove an Airnode.
 
 ```sh
 docker run -it --rm \
-  --env-file aws.env \
+  -v "$(pwd)/aws.env:/app/aws.env" \
   -v "$(pwd)/output:/app/output" \
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```
@@ -329,7 +329,7 @@ For Windows, use CMD (and not PowerShell).
 
 ```sh
 docker run -it --rm ^
-  --env-file aws.env ^
+  -v "%cd%/aws.env:/app/aws.env" ^
   -v "%cd%/output:/app/output" ^
   api3/airnode-deployer:0.7.2 remove -r output/receipt.json
 ```

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -315,7 +315,6 @@ Airnode.
 ```sh
 docker run -it --rm \
   -v "$(pwd)/aws.env:/app/aws.env" \
-  -v "$(pwd)/output:/app/output" \
   -v "$(pwd)/config:/app/config" \
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```
@@ -329,7 +328,6 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
   -v "%cd%/aws.env:/app/aws.env" ^
-  -v "%cd%/output:/app/output" ^
   -v "%cd%/config:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt
 ```

--- a/docs/airnode/v0.8/reference/deployment-files/aws-env.md
+++ b/docs/airnode/v0.8/reference/deployment-files/aws-env.md
@@ -13,7 +13,6 @@ When it is time to deploy the Airnode to AWS, the Docker
 [deployer image](../../grp-providers/docker/deployer-image.md) will need the AWS
 credentials to build the node.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```bash

--- a/docs/airnode/v0.8/reference/examples/aws-env.md
+++ b/docs/airnode/v0.8/reference/examples/aws-env.md
@@ -9,7 +9,6 @@ folder: Reference > Example Files
 
 <VersionWarning/>
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```sh

--- a/docs/airnode/v0.8/reference/templates/aws-env.md
+++ b/docs/airnode/v0.8/reference/templates/aws-env.md
@@ -15,7 +15,6 @@ used by the Docker
 Airnode to AWS. For more details, see the full description of the
 [aws.env](../deployment-files/aws-env.md) file.
 
-- Do not place double quotes (") around the value of each variable.
 - Variable names cannot contain dashes (-) or start with a number.
 
 ```sh


### PR DESCRIPTION
This PR will be rebased after #891 is merged.

After #888 I noticed there was significant duplication in a couple of deployer-related pages. This PR removes that duplication without detracting from the user flow. For example, in the guide for deploying an Airnode, the example commands are still present, while the deployer docker image page now has a reference to that section rather than all of those commands duplicated. Similarly, the docker image page is now the sole source of information on removing an airnode, rather than have those commands also be present in the deployment guide.

In doing so, this also addresses [this comment](https://github.com/api3dao/api3-docs/pull/888#issuecomment-1184118294) by @kolenic-martin .