### PR TITLE
Remove legacy/eip1559 tx options, add providerRecommendedEip1559 strategy

### DIFF
--- a/docs/airnode/v0.8/concepts/chain-providers.md
+++ b/docs/airnode/v0.8/concepts/chain-providers.md
@@ -51,33 +51,35 @@ Airnode. It then applies an arbitrary name for the blockchain provider
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei",
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
     },
     "maxConcurrency": 100
   }
@@ -115,33 +117,35 @@ Multiple providers can be used per chain. Simply add another object to
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei",
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
     },
     "maxConcurrency": 100
   }
@@ -178,33 +182,35 @@ each has a unique `id` and `type` and a list of `providers` for each.
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei",
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
     },
     "maxConcurrency": 100
   },
@@ -228,33 +234,35 @@ each has a unique `id` and `type` and a list of `providers` for each.
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei",
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
     },
     "maxConcurrency": 100
   }

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -92,33 +92,35 @@ Below is a simple chain array with a single chain provider.
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2,
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei",
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
     },
     "maxConcurrency": 100,
     "blockHistoryLimit": 300,
@@ -201,10 +203,6 @@ The below links offer details for each field:
 - [providers](../../../reference/deployment-files/config-json.md#providers)
 - [type](../../../reference/deployment-files/config-json.md#type)
 - [options](../../../reference/deployment-files/config-json.md#options)
-  - [options.txType](../../../reference/deployment-files/config-json.md#options-txtype)
-  - [options.priorityFee](../../../reference/deployment-files/config-json.md#options-priorityfee)
-  - [options.baseFeeMultiplier](../../../reference/deployment-files/config-json.md#options-basefeemultiplier)
-  - [options.gasPriceMultiplier](../../../reference/deployment-files/config-json.md#options-gaspricemultiplier)
   - [options.fulfillmentGasLimit](../../../reference/deployment-files/config-json.md#options-fulfillmentgaslimit)
   - [options.gasPriceOracle](../../../reference/deployment-files/config-json.md#options-withdrawalremainder)
   - [options.withdrawalRemainder](../../../reference/deployment-files/config-json.md#options-withdrawalremainder)

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -18,12 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
-        "priorityFee": {
-          "value": 3.12,
-          "unit": "gwei"
-        },
-        "baseFeeMultiplier": 2,
         "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
@@ -36,6 +30,14 @@
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",
             "recommendedGasPriceMultiplier": 1.2
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+            "baseFeeMultiplier": 2,
+            "priorityFee": {
+              "value": 3.12,
+              "unit": "gwei"
+            }
           },
           {
             "gasPriceStrategy": "constantGasPrice",

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -18,12 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
-        "priorityFee": {
-          "value": 3.12,
-          "unit": "gwei"
-        },
-        "baseFeeMultiplier": 2,
         "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
@@ -36,6 +30,14 @@
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",
             "recommendedGasPriceMultiplier": 1.2
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+            "baseFeeMultiplier": 2,
+            "priorityFee": {
+              "value": 3.12,
+              "unit": "gwei"
+            }
           },
           {
             "gasPriceStrategy": "constantGasPrice",

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -18,12 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
-        "priorityFee": {
-          "value": 3.12,
-          "unit": "gwei"
-        },
-        "baseFeeMultiplier": 2,
         "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
@@ -36,6 +30,14 @@
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",
             "recommendedGasPriceMultiplier": 1.2
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+            "baseFeeMultiplier": 2,
+            "priorityFee": {
+              "value": 3.12,
+              "unit": "gwei"
+            }
           },
           {
             "gasPriceStrategy": "constantGasPrice",

--- a/docs/airnode/v0.8/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/config-json.md
@@ -74,12 +74,6 @@ respective parameters.
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
@@ -92,6 +86,14 @@ respective parameters.
         {
           "gasPriceStrategy": "providerRecommendedGasPrice",
           "recommendedGasPriceMultiplier": 1.2
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei"
+          }
         },
         {
           "gasPriceStrategy": "constantGasPrice",
@@ -125,33 +127,35 @@ respective parameters.
     },
     "type": "evm",
     "options": {
-      "txType": "eip1559",
-      "priorityFee": {
-        "value": 3.12,
-        "unit": "gwei"
-      },
-      "baseFeeMultiplier": 2,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": 60,
-              "minTransactionCount": 20,
-              "pastToCompareInBlocks": 20,
-              "maxDeviationMultiplier": 2,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": 1.2,
-            },
-          {
-            "gasPriceStrategy": "constantGasPrice",
-            "gasPrice": {
-              "value": 10,
-              "unit": "gwei"
-            }
+          "gasPriceStrategy": "latestBlockPercentileGasPrice",
+          "percentile": 60,
+          "minTransactionCount": 20,
+          "pastToCompareInBlocks": 20,
+          "maxDeviationMultiplier": 2
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedGasPrice",
+          "recommendedGasPriceMultiplier": 1.2
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei"
           }
-        ]
+        },
+        {
+          "gasPriceStrategy": "constantGasPrice",
+          "gasPrice": {
+            "value": 10,
+            "unit": "gwei"
+          }
+        }
+      ],
       "withdrawalRemainder": {
         "value": 0,
         "unit": "wei"
@@ -212,50 +216,6 @@ recommended to provide `url` via interpolation from the `secrets.env` file.
 [Configuring an Airnode](../../grp-providers/guides/build-an-airnode/configuring-airnode.md#considerations-transaction-options)
 for some considerations.
 
-#### `options.txType`
-
-(required) - The transaction type to use:
-
-- `"legacy"` - Legacy Transaction Type
-- `"eip1559"` -
-  [EIP-1559 Transaction Type](https://eips.ethereum.org/EIPS/eip-1559)
-
-#### `options.priorityFee`
-
-(optional) - An object that configures the EIP-1559 Priority Fee. Defaults:
-`{"value": 3.12, "unit": "gwei"}`.
-
-##### `options.priorityFee.value`
-
-(required) - A number specifying the EIP-1559 priority fee value.
-
-##### `options.priorityFee.unit`
-
-(required) - The unit of the priority fee value. It can be one of the following:
-
-- `wei`
-- `kwei`
-- `mwei`
-- `gwei`
-- `szabo`
-- `finney`
-- `ether`
-
-#### `options.baseFeeMultiplier`
-
-(optional) - Number multiplied by the Base Fee to yield the Maximum Fee for
-EIP-1559 transactions. Defaults to: `2`.
-
-The resulting Maximum Fee will equal
-`(Base Fee * baseFeeMultiplier) + priorityFee`
-
-#### `options.gasPriceMultiplier`
-
-(optional) - A number with a maximum of two decimals that gets multiplied by the
-legacy gas price. No multiplier is used by default.
-
-The resulting Gas Price will equal `Gas Price * gasPriceMultiplier`
-
 #### `options.fulfillmentGasLimit`
 
 (required) - The maximum gas limit allowed when Airnode responds to a request,
@@ -298,6 +258,7 @@ the specified order.
 
 - `"latestBlockPercentileGasPrice"`
 - `"providerRecommendedGasPrice"`
+- `"providerRecommendedEip1559GasPrice"`
 - `"constantGasPrice"`
 
 #### Strategy: `"latestBlockPercentileGasPrice"`
@@ -328,6 +289,37 @@ against large gas price spikes.
 (required) - A number with a maximum of two decimals that gets multiplied by the
 provider reported gas price. The resulting Gas Price will equal
 `Gas Price * providerRecommendedGasPrice`
+
+#### Strategy: `"providerRecommendedEip1559GasPrice"`
+
+##### `priorityFee`
+
+(required) - An object that configures the EIP-1559 Priority Fee. Defaults:
+`{"value": 3.12, "unit": "gwei"}`.
+
+##### `priorityFee.value`
+
+(required) - A number specifying the EIP-1559 priority fee value.
+
+##### `priorityFee.unit`
+
+(required) - The unit of the priority fee value. It can be one of the following:
+
+- `wei`
+- `kwei`
+- `mwei`
+- `gwei`
+- `szabo`
+- `finney`
+- `ether`
+
+##### `baseFeeMultiplier`
+
+(required) - Number multiplied by the Base Fee to yield the Maximum Fee for
+EIP-1559 transactions. Defaults to: `2`.
+
+The resulting Maximum Fee will equal
+`(Base Fee * baseFeeMultiplier) + priorityFee`
 
 #### Strategy: `"constantGasPrice"`
 

--- a/docs/airnode/v0.8/reference/examples/config-cloud.json
+++ b/docs/airnode/v0.8/reference/examples/config-cloud.json
@@ -18,12 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
-        "priorityFee": {
-          "value": 3.12,
-          "unit": "gwei"
-        },
-        "baseFeeMultiplier": 2,
         "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
@@ -36,6 +30,14 @@
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",
             "recommendedGasPriceMultiplier": 1.2
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+            "baseFeeMultiplier": 2,
+            "priorityFee": {
+              "value": 3.12,
+              "unit": "gwei"
+            }
           },
           {
             "gasPriceStrategy": "constantGasPrice",

--- a/docs/airnode/v0.8/reference/examples/config-local.json
+++ b/docs/airnode/v0.8/reference/examples/config-local.json
@@ -17,14 +17,7 @@
         }
       },
       "type": "evm",
-      "options": {
-        "txType": "eip1559",
-        "priorityFee": {
-          "value": 3.12,
-          "unit": "gwei"
-        },
-        "baseFeeMultiplier": 2
-      },
+      "options": {},
       "maxConcurrency": 100,
       "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
@@ -38,6 +31,14 @@
         {
           "gasPriceStrategy": "providerRecommendedGasPrice",
           "recommendedGasPriceMultiplier": 1.2
+        },
+        {
+          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+          "baseFeeMultiplier": 2,
+          "priorityFee": {
+            "value": 3.12,
+            "unit": "gwei"
+          }
         },
         {
           "gasPriceStrategy": "constantGasPrice",

--- a/docs/airnode/v0.8/reference/templates/config-json.md
+++ b/docs/airnode/v0.8/reference/templates/config-json.md
@@ -59,30 +59,32 @@ building a config.json file.
       },
       "type": "<FILL_*>",
       "options": {
-        "txType": "<FILL_*>",
-        "priorityFee": {
-          "value": <FILL_NUMBER>,
-          "unit": "<FILL_*>"
-        },
-        "baseFeeMultiplier": <FILL_NUMBER>,
         "fulfillmentGasLimit": <FILL_NUMBER>,
         "gasPriceOracle": [
-        {
-              "gasPriceStrategy": "latestBlockPercentileGasPrice",
-              "percentile": <FILL_NUMBER>,
-              "minTransactionCount": <FILL_NUMBER>,
-              "pastToCompareInBlocks": <FILL_NUMBER>,
-              "maxDeviationMultiplier": <FILL_NUMBER>,
-            },
-            {
-              "gasPriceStrategy": "providerRecommendedGasPrice",
-              "recommendedGasPriceMultiplier": <FILL_NUMBER>,
-            },
+          {
+            "gasPriceStrategy": "latestBlockPercentileGasPrice",
+            "percentile": <FILL_NUMBER>,
+            "minTransactionCount": <FILL_NUMBER>,
+            "pastToCompareInBlocks": <FILL_NUMBER>,
+            "maxDeviationMultiplier": <FILL_NUMBER>,
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedGasPrice",
+            "recommendedGasPriceMultiplier": <FILL_NUMBER>,
+          },
+          {
+            "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
+            "baseFeeMultiplier": <FILL_NUMBER>,
+            "priorityFee": {
+              "value": <FILL_NUMBER>,
+              "unit": "<FILL_*>"
+            }
+          },
           {
             "gasPriceStrategy": "constantGasPrice",
             "gasPrice": {
               "value": <FILL_NUMBER>,
-              "unit": "gwei"
+              "unit": "<FILL_*>"
             }
           }
         ]


### PR DESCRIPTION
This removes EIP1559/Legacy chain transaction options and adds `providerRecommendedEip1559GasPrice` as a new strategy, I also fixed some of the json formatting that was off.