### PR TITLE
578 lib retry external links

### DIFF
--- a/libs/link-validator-ignore.json
+++ b/libs/link-validator-ignore.json
@@ -1,0 +1,1 @@
+["https://developer.offchainlabs.com/docs/arbgas"]


### PR DESCRIPTION
Closes #578
- The `link-validator.js` now uses an external ignore file `link-validator-ignore.json`.
- A timeout (by Axios) of 10,000ms will be retried just once.