### PR TITLE
738 latest from themeconfig site

### DIFF
--- a/docs/.vuepress/components/dev/ThemeConfigJson.vue
+++ b/docs/.vuepress/components/dev/ThemeConfigJson.vue
@@ -1,0 +1,21 @@
+<!--
+Used to output the value of a few VuePress system variables to the browser console.
+-->
+
+<template>
+  <span> </span>
+</template>
+
+<script>
+export default {
+  name: 'ThemeConfigJson',
+  mounted() {
+    this.$nextTick(async function () {
+      console.log('$site:');
+      console.log(this.$site);
+      console.log('$themeConfig:');
+      console.log(this.$themeConfig);
+    });
+  },
+};
+</script>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -48,6 +48,7 @@ module.exports = {
   },
   themeConfig: {
     startPath: '/airnode/v0.7/',
+    latestVersions: { airnode: '/airnode/v0.7/', ois: '/ois/v1.0' },
     sidebarDepth: 0,
     displayAllHeaders: false,
     logo: '/img/logo.png',

--- a/docs/dapis/README.md
+++ b/docs/dapis/README.md
@@ -35,7 +35,7 @@ Developers use the
 [`DapiServer.sol`](https://github.com/api3dao/airnode-protocol-v1/blob/main/contracts/dapis/DapiServer.sol)
 contract to access dAPIs. `DapiServer.sol` reads directly from its data store of
 Beacons, which are powered by API provider-owned and operated
-[Airnodes](../airnode/v0.7/).
+<router-link :to="$themeConfig.latestVersions.airnode">Airnodes</router-link>.
 
 > <img src="./assets/images/dapp-beacon.png" width="550px"/>
 

--- a/docs/dapis/introduction/why-power.md
+++ b/docs/dapis/introduction/why-power.md
@@ -29,9 +29,10 @@ dAPIs are _first-party_, API provider-centric versions of live data feeds, which
 are typically used in Web3 applications of financial nature. By directly
 providing continuously updated streams of off-chain data called _Beacons_, API
 providers can power dAPIs. For this, the API provider needs to own and operate
-an [Airnode](/airnode/v0.7/), which is configured to power Beacons that are the
-building blocks of dAPIs. API3 builds the solutions that are used in this
-process, and guides API providers in utilizing them.
+an <router-link :to="$themeConfig.latestVersions.airnode">Airnode</router-link>,
+which is configured to power Beacons that are the building blocks of dAPIs. API3
+builds the solutions that are used in this process, and guides API providers in
+utilizing them.
 
 API3 operates dAPIs on a number of chains and actively works on building new
 integrations and business relations. This means the API provider does not need

--- a/docs/dapis/introduction/why-use-dapis.md
+++ b/docs/dapis/introduction/why-use-dapis.md
@@ -18,8 +18,9 @@ transparency, cost-efficiency and scalability in a turn-key package.
 **Security**: Data used to update a first-party data feed is cryptographically
 signed by the owner of the data. This means that the data that will update a
 feed cannot be tampered with once it leaves the source. Furthermore, the API
-providers host our first-party oracle node, [Airnode](/airnode/v0.7/), to push
-the data to the chain themselves. This renders denial of service attacks by
+providers host a first-party oracle node,
+<router-link :to="$themeConfig.latestVersions.airnode">Airnode</router-link>, to
+push the data to the chain themselves. This renders denial of service attacks by
 third parties ineffective.
 
 **Transparency**: The cryptographic signatures prove that the data that updates

--- a/docs/dev/release-notes.md
+++ b/docs/dev/release-notes.md
@@ -12,22 +12,6 @@ Use this page as a checklist when creating a new release for any versioned
 documentation set. It may be necessary to reference other pages in the `/dev`
 document set.
 
-::: danger TODO:
-
-It is possible to use a $themeConfig variable such as `airnodeLatest` to use in
-the path of a link. However they canot be used in markdown links, only with
-`router-link`.
-
-Example: <router-link :to="'/airnode/'+$frontmatter.path">Link</router-link>
-
-This could be used when a document set sends the user to another versioned doc
-set where the latest version is desired.
-
-It is not useful when links go to a GitHub repo README since the versions must
-match a tag at the repo.
-
-:::
-
 ## Airnode
 
 - Be sure all links to Github use the proper tag. Look for use of `master`,

--- a/docs/dev/sidebar.js
+++ b/docs/dev/sidebar.js
@@ -18,6 +18,7 @@ module.exports = [
       '/dev/prettier',
       '/dev/deployment',
       '/dev/release-notes.md',
+      '/dev/system-variables.md',
       '/dev/quirks',
     ],
   },

--- a/docs/dev/system-variables.md
+++ b/docs/dev/system-variables.md
@@ -1,0 +1,42 @@
+---
+title: System Variables
+---
+
+# {{$frontmatter.title}}
+
+<dev-ThemeConfigJson/>
+
+Use the browser console to view the following system variables.
+
+- $site
+- $themeConfig
+
+`$site and $themeConfig` values can be used in markdown content, inside Vue
+elements such as `router-link` (expressed as `:to="$themeConfig.var`"), and
+inside HTML elements such as img. They will not work inside markdown elements
+such as links and images.
+
+This will **not** work:
+
+```md
+[Link]({{$themeConfig.latestVersions.airnode}})
+![Image]({{$themeConfig.imagePath}})
+```
+
+This will work:
+
+(Airnode latest version: <router-link :to="$themeConfig.latestVersions.airnode">
+{{$themeConfig.latestVersions.airnode}} </router-link>)
+
+<!-- prettier-ignore-->
+```html
+<router-link :to="$themeConfig.latestVersions.airnode">
+    {{$themeConfig.latestVersions.airnode}}
+</router-link>
+```
+
+HTML image
+
+```html
+<img :src="$themeConfig.imagePath" />
+```


### PR DESCRIPTION
Closes #738 

Add `$themeConfig.latestVersions` to `config.js` to be used by internal links with router-link.

Also add a component that display `$site` and `themeConfig` in the browser console when the page `/dev/system-varaibles.md` in viewed.