### PR TITLE
Update service coverage phrasing and whitepaper to v1.0.3

### DIFF
--- a/docs/airnode/v0.7/README.md
+++ b/docs/airnode/v0.7/README.md
@@ -39,9 +39,8 @@ its ease of implementation.
 ::: tip
 
 If you want to learn more about the Airnode experience, read Section 4 of the
-<a href="/api3-whitepaper-v1.0.2.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" 
-target="_api3-whitepaper">API3 Whitepaper</a>, _Airnode: A Node Designed for
-First-Party Oracles_.
+<a href="/api3-whitepaper-v1.0.3.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+Whitepaper</a>, _Airnode: A Node Designed for First-Party Oracles_.
 
 :::
 
@@ -137,7 +136,7 @@ observed the following barriers to oracle onboarding and operation:
    This disqualifies the vast majority of API providers for compliance-related,
    legal and accounting reasons. In addition, any scheme that requires API
    providers to stake funds is categorically rejected for similar reasons
-   related to financia risks.
+   related to financial risks.
 
 ## Airnode Features
 

--- a/docs/airnode/v0.8/README.md
+++ b/docs/airnode/v0.8/README.md
@@ -39,9 +39,8 @@ its ease of implementation.
 ::: tip
 
 If you want to learn more about the Airnode experience, read Section 4 of the
-<a href="/api3-whitepaper-v1.0.2.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" 
-target="_api3-whitepaper">API3 Whitepaper</a>, _Airnode: A Node Designed for
-First-Party Oracles_.
+<a href="/api3-whitepaper-v1.0.3.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+Whitepaper</a>, _Airnode: A Node Designed for First-Party Oracles_.
 
 :::
 
@@ -137,7 +136,7 @@ observed the following barriers to oracle onboarding and operation:
    This disqualifies the vast majority of API providers for compliance-related,
    legal and accounting reasons. In addition, any scheme that requires API
    providers to stake funds is categorically rejected for similar reasons
-   related to financia risks.
+   related to financial risks.
 
 ## Airnode Features
 

--- a/docs/api3/README.md
+++ b/docs/api3/README.md
@@ -34,7 +34,7 @@ problem, **API3** aims to provide a much more optimal solution.
 ::: tip API3 Whitepaper (pdf)
 
 For a detailed discussion of the API3 project, read the
-<a href="/api3-whitepaper-v1.0.2.pdf" target="_api3-whitepaper">API3
+<a href="/api3-whitepaper-v1.0.3.pdf" target="_api3-whitepaper">API3
 Whitepaper</a>.
 
 :::
@@ -57,7 +57,7 @@ implementation.
 ::: tip
 
 Learn more about Airnode Read Section 4 of the
-<a href="/api3-whitepaper-v1.0.2.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
+<a href="/api3-whitepaper-v1.0.3.pdf#Airnode:%20A%20Node%20Designed%20for%20First-Party%20Oracles" target="_api3-whitepaper">API3
 Whitepaper</a> _Airnode: A Node Designed for First-Party Oracles_
 
 :::
@@ -78,7 +78,7 @@ learn more.
 ::: tab The Whitepaper
 
 **Abstract from the
-<a href="/api3-whitepaper-v1.0.2.pdf" target="_api3-whitepaper">API3
+<a href="/api3-whitepaper-v1.0.3.pdf" target="_api3-whitepaper">API3
 Whitepaper</a>**
 
 With decentralized applications beginning to provide meaningful services in

--- a/docs/api3/introduction/contributing.md
+++ b/docs/api3/introduction/contributing.md
@@ -25,7 +25,7 @@ sure to ask any questions you have on
   know about superficially.
 
 - To get a general grasp of the project, read the
-  <a href="/api3-whitepaper-v1.0.2.pdf" target="_api3-whitepaper">API3
+  <a href="/api3-whitepaper-v1.0.3.pdf" target="_api3-whitepaper">API3
   Whitepaper</a> and our [blog posts](./symlink-blog-posts.md) on Medium.
 
 - Read the entirety of these docs. Take notes and cross-reference, but do not

--- a/docs/api3/introduction/dapis.md
+++ b/docs/api3/introduction/dapis.md
@@ -22,7 +22,7 @@ same solution can be reached through a more useful lens.
 Decentralized applications cannot access Web APIs, and oracle solutions aim to
 build decentralized interfaces to facilitate this. However, this approach
 results in an inferior solution and ecosystem (see the
-<a href="/api3-whitepaper-v1.0.2.pdf" target="_api3-whitepaper">API3
+<a href="/api3-whitepaper-v1.0.3.pdf" target="_api3-whitepaper">API3
 Whitepaper</a> for a detailed explanation).
 
 > <img src="../assets/images/dapi.png" width="450px"/>

--- a/docs/api3/introduction/first-party-oracles.md
+++ b/docs/api3/introduction/first-party-oracles.md
@@ -37,7 +37,7 @@ First-Party vs Third-Party Oracles
 for a comparison of the two types of oracles._ -->
 
 Third party oracles are both insecure and expensive (see the
-<a href="/api3-whitepaper-v1.0.2.pdf#Issues%20with%20Third-Party%20Oracles%20as%20Middlemen" target="_api3-whitepaper">API3
+<a href="/api3-whitepaper-v1.0.3.pdf#Issues%20with%20Third-Party%20Oracles%20as%20Middlemen" target="_api3-whitepaper">API3
 Whitepaper</a> _Issues with Third-Party Oracles as Middlemen_ for a detailed
 explanation). In contrast, first-party oracles are both secure and
 cost-efficient due to not having a middleman on the interface path.

--- a/docs/dao-members/introduction/api3-dao.md
+++ b/docs/dao-members/introduction/api3-dao.md
@@ -56,7 +56,7 @@ based on expert opinion. As API3 operations expand, this governance hierarchy
 may demand additional layers in the form of subDAOs.
 
 To learn more about hierarchical team structures
-<a href="/api3-whitepaper-v1.0.2.pdf#API3%20DAO" target="_api3-whitepaper"> see
+<a href="/api3-whitepaper-v1.0.3.pdf#API3%20DAO" target="_api3-whitepaper"> see
 Section 5.3 of the API3 Whitepaper</a>.
 
 ### subDAO

--- a/docs/dao-members/introduction/dao-pool.md
+++ b/docs/dao-members/introduction/dao-pool.md
@@ -12,9 +12,9 @@ folder: Introduction
 
 The API3 DAO has a single staking pool called the **DAO pool**. Staking API3
 tokens in the pool will grant representation and staking rewards, but at the
-same time, the staked tokens will be used as collateral to pay out coverage
-service claims as needed. To do this, the pool focuses on three token utilities
-and implements a coverage service which by design balances rewards and risks
+same time, the staked tokens will be used as collateral to pay out service
+coverage claims as needed. To do this, the pool focuses on three token utilities
+and implements service coverage which, by design, balances rewards and risks
 through responsible governance.
 
 ## Tokens
@@ -31,20 +31,20 @@ have voting rights. They are subject to market value and inflation.
 
 ### Staked Tokens
 
-Staked API3 tokens are used as collateral for the on-chain coverage service that
+Staked API3 tokens are used as collateral for the on-chain service coverage that
 will provide quantifiable and trustless security guarantees to dAPI users. These
 mechanics will remove the need for a central authority at the ecosystem level.
 
 Staking simply means you are placing API3 tokens into the DAO pool. When staking
 tokens to the DAO pool you gain access to weekly staking rewards but also share
-in the risk of the coverage service. You are also granted voting rights on
-active DAO proposals and inflationary rewards.
+in the risk of service coverage. You are also granted voting rights on active
+DAO proposals and inflationary rewards.
 
-To stake your tokens see [StakingTokens](../dashboard/staking.md). You can stake
-as many times as you’d like. Your percentage of all the tokens in the DAO pool
-are directly related to your percentage of the rewards and the risks. If you
-stake 10% of the pool you earn 10% of rewards and will pay 10% of coverage
-service claims.
+To stake your tokens see [Staking Tokens](../dashboard/staking.md). You can
+stake as many times as you’d like. Your percentage of all the tokens in the DAO
+pool are directly related to your percentage of the rewards and the risks. If
+you stake 10% of the pool you earn 10% of rewards and will pay 10% of service
+coverage claims.
 
 ## Token Utilities
 
@@ -60,7 +60,7 @@ _Main utilities of the API3 token._
 >
 > 1. [Staking](dao-pool.md#staking): Grants membership in the API3 DAO and
 >    rights to [inflationary rewards](dao-pool.md#inflationary-rewards).
-> 1. [Collateral](dao-pool.md#collateral): Backs coverage services that protect
+> 1. [Collateral](dao-pool.md#collateral): Backs service coverage that protect
 >    users from damages caused by dAPI malfunctions.
 > 1. [Governance](dao-pool.md#governance): Grants direct representation in the
 >    API3 DAO.
@@ -72,7 +72,7 @@ them to govern in a way that minimizes **_security_** risks. "_Security_" refers
 to a "guarantee or reliability of dAPI service"
 
 Reference
-<a href="/api3-whitepaper-v1.0.2.pdf#API3%20tokenomics" target="_api3-whitepaper">section
+<a href="/api3-whitepaper-v1.0.3.pdf#API3%20tokenomics" target="_api3-whitepaper">section
 5.4 _"API3 Tokenomics"_</a> of the API3 whitepaper.
 
 ### Staking
@@ -80,21 +80,21 @@ Reference
 The staking utility incentivizes participation in the DAO and alignment of
 incentives. By staking your API3 tokens into the DAO pool, you receive
 governance voting rights and take part in providing API3 users with quantifiable
-_security_ in the form of the coverage service. The DAO pool also grants you
-inflationary rewards and exposes you to the risk of coverage service claims.
+_security_ in the form of service coverage. The DAO pool also grants you
+inflationary rewards and exposes you to the risk of service coverage claims.
 
 > <img src="../assets/images/dao-pool-staking.png" width="350"/>
 >
 > <p class="diagram-line" style="color:gray;margin-top:25px;">Staked tokens in the DAO pool grant 
 > governance voting rights, inflationary rewards and are used to fund the coverage 
-> service which exposes staked tokens to the risks of coverage service claims.</p>
+> service which exposes staked tokens to the risks of service coverage claims.</p>
 
 **Benefits:**
 
-- Generate shares (tokens) in the DAO through revenue sharing from the coverage
-  service fees.
+- Generate shares (tokens) in the DAO through revenue sharing from service
+  coverage fees.
 - Generates inflationary rewards by decreasing the circulating supply of API3
-  tokens through revenue burn from the coverage service fees.
+  tokens through revenue burn from service coverage fees.
 - Improved token inflation protection compared to unstaked tokens.
 - Voting privileges on DAO proposals.
 
@@ -106,8 +106,8 @@ inflationary rewards and exposes you to the risk of coverage service claims.
 To stake your tokens use the [Dashboard](../dashboard/staking.md). You can stake
 as many times as you’d like. Your percentage of all the tokens in the DAO pool
 are directly related to your percentage of the rewards and the risks. If you
-stake 10% of the pool you earn 10% of rewards and will pay 10% of coverage
-service claims.
+stake 10% of the pool you earn 10% of rewards and will pay 10% of service
+coverage claims.
 
 ### Collateral
 
@@ -123,15 +123,15 @@ decentralized data feeds.
 
 Exposing the governing parties to the risk would align their incentives with
 that of the DAO. The governing parties need to be penalized when a dAPI
-malfunction occurs using an onchain coverage service that provides dAPI users
+malfunction occurs using an onchain service coverage that provides dAPI users
 with quantifiable and trustless security guarantees. The
-[Coverage Service](dao-pool.md#coverage-service) uses staked tokens of the DAO
+[Service Coverage](dao-pool.md#service-coverage) uses staked tokens of the DAO
 pool as collateral, which means that when a dAPI malfunction is confirmed
 through the dispute resolution protocol, user damages will be covered from the
 pool's staked tokens.
 
 Reference
-<a href="/api3-whitepaper-v1.0.2.pdf#Collateral" target="_api3-whitepaper">section
+<a href="/api3-whitepaper-v1.0.3.pdf#Collateral" target="_api3-whitepaper">section
 5.4.2 _"Collateral"_</a> of the API3 whitepaper.
 
 ### Governance
@@ -143,14 +143,14 @@ The only way to gain representation in the DAO is to stake API3 tokens in the
 pool. Staked tokens give their holders the right to take part in the governance
 of the API3 ecosystem through the DAO. To vote token holders must stake their
 API3 tokens in the pool, which also gives them access to weekly staking rewards
-but also share in the risk of the coverage service.
+but also share in the risk of service coverage.
 
 All governing parties will be exposed to all risks and rewards of API3, and will
 govern to optimize them. Inflationary rewards and the staked tokens being used
 as collateral will create a positive feedback loop in terms of governance
 quality. Initial token holders will have to stake and expose themselves to risk
 if they do not want to lose value to inflation. If they misgovern and lose
-collateral through coverage service claims, these tokens will get returned to
+collateral through service coverage claims, these tokens will get returned to
 the open market, from where they will be acquired by new governing parties. In
 contrast, if initial token holders govern well and cause token scarcity in the
 market, the representation distribution will be protected. In other words,
@@ -168,9 +168,9 @@ clients. API3 follows the same scheme for dAPIs.
 To gain access to a dAPI, a dApp will pay a recurring subscription fee, which
 may be fixed or customized for the dApp based on a specific use case. These
 prices will be determined by the respective team, and will include a premium if
-the dApp wants to receive the [Coverage Service](dao-pool.md#coverage-service).
-The payment can be made in any cryptocurrency, which will be received by the DAO
-in API3 tokens through a liquidity pool-based decentralized exchange.
+the dApp wants to receive [Service Coverage](dao-pool.md#service-coverage). The
+payment can be made in any cryptocurrency, which will be received by the DAO in
+API3 tokens through a liquidity pool-based decentralized exchange.
 
 ### API provider compensation
 
@@ -185,7 +185,7 @@ return of the proof that the API provider is compensated in fiat by the grantee.
 API3 aims to set up, maintain, and [monetize](dao-pool.md#monetization) dAPIs at
 scale. Its success in doing so can be estimated by its total revenue, as this
 will increase with the number of dAPIs and the amount of funds secured by them.
-API3 generates revenue through subscription fees and coverage service fees. The
+API3 generates revenue through subscription fees and service coverage fees. The
 fees can be made in any cryptocurrency, which will be received by the DAO in
 API3 tokens through a liquidity pool-based decentralized exchange. To align the
 governance incentives with API3’s success, combined with the inflationary
@@ -195,7 +195,7 @@ claim risks rather than revenue sharing.
 
 > <img src="../assets/images/dao-pool-staking-2.png" width="450"/>
 >
-> <p class="diagram-line" style="color:gray;margin-top:25px;">Fees from revenue are burned. Inflationary rewards are distributed by the DAO. Coverage service claims are paid to dAPI covered entities from the pool of staked tokens.</p>
+> <p class="diagram-line" style="color:gray;margin-top:25px;">Fees from revenue are burned. Inflationary rewards are distributed by the DAO. Service coverage claims are paid to dAPI covered entities from the pool of staked tokens.</p>
 
 ### Earning Rewards
 
@@ -213,9 +213,9 @@ share will not always be one token.
 
 In essence, inflationary rewards force token holders to stake and preserve the
 value of their tokens. However, staking is risky due to the funds being used as
-collateral for the [Coverage Service](dao-pool.md#coverage-service), and forces
-the staker to participate in governance to ensure that the risk is minimized. As
-a combination of the two, an inflationary governance token used as collateral
+collateral for [Service Coverage](dao-pool.md#service-coverage), and forces the
+staker to participate in governance to ensure that the risk is minimized. As a
+combination of the two, an inflationary governance token used as collateral
 forces all token holders to participate in governance, which is ideal because it
 maximizes the decentralization of governance. Inflationary rewards are paid
 weekly by an implicit and automatic process through an on-chain contract.
@@ -296,9 +296,9 @@ later, etc.) This 1 year-lock is the secret sauce to good decentralized
 governance, it essentially aligns the incentives of the stakers/governors with
 the ones of the DAO/project/token for a whole year.
 
-## Coverage Service
+## Service Coverage
 
-::: warning Please note Coverage Service products are not implemented yet.
+::: warning Please note Service Coverage products are not implemented yet.
 
 Before they are, a proposal with a 50% quorum requirement will have to be passed
 for them to go active
@@ -306,43 +306,43 @@ for them to go active
 :::
 
 API3 provides dAPI users with a quantifiable level of _security_ in the form of
-an on-chain coverage service. Staked tokens in the DAO pool are used to cover
+an on-chain service coverage. Staked tokens in the DAO pool are used to cover
 potential financial losses from dAPI malfunctions that the dAPI consumer might
 incur. This accomplishes two goals.
 
-- The coverage service acts as a well-defined and trustless safety net in case
-  of a dAPI malfunction.
+- Service coverage acts as a well-defined and trustless safety net in case of a
+  dAPI malfunction.
 - It holds the governing parties responsible for dAPI malfunctions, and thus
   incentivizes them to govern towards more secure dAPIs.
 
-API3 co-developed an on-chain coverage service with Kleros that provides
-quantifiable and trustless _security_ to dAPI users. This coverage service will
+API3 co-developed an on-chain service coverage with Kleros that provides
+quantifiable and trustless _security_ to dAPI users. This service coverage will
 protect the dAPI user against damages caused by certain dAPI malfunctions up to
 a payout limit. Note that even if API3 did not provide this service, the dAPI
-user could have received on-chain coverage services using a third party
-solution. Such a solution would tend towards charging very high coverage service
-premiums, as they would not have access to the information and expertise to
-accurately assess dAPI risks.
+user could have received on-chain service coverage using a third party solution.
+Such a solution would tend towards charging very high service coverage premiums,
+as they would not have access to the information and expertise to accurately
+assess dAPI risks.
 
-The proposed coverage service is special in the way that it is collateralized by
+The proposed service coverage is special in the way that it is collateralized by
 the funds staked by the governing parties of the API3 DAO into the DAO pool.
 Therefore, it not only provides _security_ to the dAPI user, but also creates a
 very strong incentive for dAPIs to be governed in a way that dAPI _security_ is
-maximized, which will further decrease coverage service costs.
+maximized, which will further decrease service coverage costs.
 
 ### Claim Risks
 
-The staked tokens in the pool are used as collateral for coverage service
+The staked tokens in the pool are used as collateral for service coverage
 claims. Any payout results in the reduction of the total token count in the
 pool. The reduction is charged against each entity's percentage of tokens in the
 pool.
 
-::: tip Example
+::: tip Claim Risks Example
 
-Claim Risks User X and Y both stake 500 API3 tokens, so each has 50% ownership
-in a 1000 token DAO pool. There is a coverage service claim payout of 3.4 tokens
-and the pool is now 996.6 tokens. X and Y now own 498.3 tokens each based on
-their 50% ownership.
+User X and Y both stake 500 API3 tokens, so each has 50% ownership in a 1000
+token DAO pool. There is a service coverage claim payout of 3.4 tokens and the
+pool is now 996.6 tokens. X and Y now own 498.3 tokens each based on their 50%
+ownership.
 
 :::
 
@@ -355,5 +355,5 @@ To insure against potential system failures, the DAO pool can empower special
 transfers tokens from the DAO pool to the recipient. When this occurs, the total
 number of staked tokens goes down, and pool share value goes down in turn.
 Reference
-<a href="/api3-whitepaper-v1.0.2.pdf#Insurance process" target="_api3-whitepaper">section
-6.3 _"Coverage service process"_</a> of the API3 whitepaper.
+<a href="/api3-whitepaper-v1.0.3.pdf#Service%20coverage%20process" target="_api3-whitepaper">section
+6.3 _"Service coverage process"_</a> of the API3 whitepaper.

--- a/docs/dao-members/introduction/dao-pool.md
+++ b/docs/dao-members/introduction/dao-pool.md
@@ -91,8 +91,6 @@ inflationary rewards and exposes you to the risk of service coverage claims.
 
 **Benefits:**
 
-- Generate shares (tokens) in the DAO through revenue sharing from service
-  coverage fees.
 - Generates inflationary rewards by decreasing the circulating supply of API3
   tokens through revenue burn from service coverage fees.
 - Improved token inflation protection compared to unstaked tokens.


### PR DESCRIPTION
Closes #618 with links to the v1.0.3 whitepaper. This also updates the phrase `coverage service` to `service coverage` to match what is used in the whitepaper.

@wkande - note this PR will require the v1.0.3 [whitepaper pdf](https://github.com/api3dao/api3-whitepaper/blob/v1.0.3/api3-whitepaper.pdf) to be added to the docs.

@ErichDylus perhaps you could also take a look?