### PR TITLE
873 search multiple headings

### DIFF
--- a/archived/components/SearchBox2.vue
+++ b/archived/components/SearchBox2.vue
@@ -1,0 +1,207 @@
+<template>
+  <div
+    class="sb-search2-modal"
+    v-click-outside="onClickOutside"
+    style="user-select: none"
+  >
+    <div class="sb-search-input-box">
+      <input
+        ref="input"
+        aria-label="Search"
+        :value="query"
+        :class="{ focused: focused }"
+        placeholder="minimum 3 characters"
+        autocomplete="off"
+        spellcheck="false"
+        @input="query = $event.target.value"
+        @focus="focused = true"
+        @blur="focused = false"
+        @keyup.enter="go(focusIndex)"
+        @keyup.up="onUp"
+        @keyup.down="onDown"
+      />&nbsp;&nbsp;<span v-if="suggestions">({{ suggestions.length }})</span>
+    </div>
+    <search-SearchBoxList2 :suggestions="suggestions" />
+  </div>
+</template>
+
+<script>
+import Vue from 'vue';
+import vClickOutside from 'v-click-outside';
+Vue.use(vClickOutside);
+
+import matchQuery from './match-query';
+
+/* global SEARCH_MAX_SUGGESTIONS, SEARCH_PATHS, SEARCH_HOTKEYS */
+export default {
+  name: 'SearchBox2',
+  data() {
+    return {
+      query: localStorage.getItem('search_query') || '',
+      scrollY: localStorage.getItem('scrollY'),
+      focused: false,
+      focusIndex: 0,
+      currentDocSetWithVersion: undefined, // The doc set the user is reading
+    };
+  },
+
+  computed: {
+    showSuggestions() {
+      return this.focused && this.suggestions && this.suggestions.length;
+    },
+    suggestions() {
+      const query = this.query.trim().toLowerCase();
+      if (!this.currentDocSetWithVersion) {
+        this.setCurrentDocSet();
+      }
+      if (query.length < 3) {
+        localStorage.setItem('search_query', '');
+        return;
+      }
+      localStorage.setItem('search_query', query);
+
+      const { pages } = this.$site;
+      const max =
+        this.$site.themeConfig.searchMaxSuggestions || SEARCH_MAX_SUGGESTIONS;
+
+      const res = [];
+      for (let i = 0; i < pages.length; i++) {
+        if (res.length >= max) break;
+        const p = pages[i];
+
+        // Filter by the path in "p"
+        if (!this.filterByPath(p)) {
+          continue;
+        }
+
+        if (matchQuery(query, p)) {
+          res.push(p);
+        } else if (p.headers) {
+          for (let j = 0; j < p.headers.length; j++) {
+            if (res.length >= max) break;
+            const h = p.headers[j];
+            if (h.title && matchQuery(query, p, h.title)) {
+              res.push(
+                Object.assign({}, p, {
+                  path: p.path + '#' + h.slug,
+                  folder: p.folder,
+                  header: h,
+                })
+              );
+            }
+          }
+        }
+      }
+      return res;
+    },
+  },
+
+  mounted() {
+    this.placeholder = this.$site.themeConfig.searchPlaceholder || '';
+    document.addEventListener('keydown', this.onHotkey);
+  },
+
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.onHotkey);
+  },
+
+  methods: {
+    onClickOutside(url, event) {
+      this.$emit('clicked'); // goes to parent method
+    },
+    setCurrentDocSet() {
+      const docSet = this.$route.path.split('/');
+
+      if (['airnode', 'ois'].includes(docSet[1])) {
+        this.currentDocSetWithVersion = '/' + docSet[1] + '/' + docSet[2];
+      } else {
+        this.currentDocSetWithVersion = '/' + docSet[1];
+      }
+    },
+    filterByPath(p) {
+      // Only allow the search to show items found in hte current doc set
+      if (p.regularPath.indexOf(this.currentDocSetWithVersion) === 0) {
+        return true;
+      }
+      return false;
+    },
+    onHotkey(event) {
+      if (
+        event.srcElement === document.body &&
+        SEARCH_HOTKEYS.includes(event.key)
+      ) {
+        this.$refs.input.focus();
+        event.preventDefault();
+      }
+    },
+
+    onUp() {
+      if (this.showSuggestions) {
+        if (this.focusIndex > 0) {
+          this.focusIndex--;
+        } else {
+          this.focusIndex = this.suggestions.length - 1;
+        }
+      }
+    },
+
+    onDown() {
+      if (this.showSuggestions) {
+        if (this.focusIndex < this.suggestions.length - 1) {
+          this.focusIndex++;
+        } else {
+          this.focusIndex = 0;
+        }
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.sb-search2-modal {
+  font-size: medium;
+  padding: 10px;
+  border-radius: 6px;
+  color: gray;
+  position: absolute;
+  left: 0px;
+  top: 46px;
+  width: 300px !important;
+  height: 700px;
+  z-index: 999;
+  background: #ffffff;
+  box-shadow: 2px 2px 20px 1px;
+  overflow-y: auto;
+}
+</style>
+
+<style lang="stylus">
+
+.sb-show-path{
+  font-size x-large
+  height: 2rem
+}
+.sb-search-input-box
+
+  input
+    width 13rem
+    cursor text
+    height 1.5rem
+    color lighten($textColor, 25%)
+    display inline-block
+    border 2px solid darken($borderColor, 10%)
+    border-radius 2rem
+    font-size 1.2rem
+    line-height 2rem
+    padding 0.3rem 0.5rem .4rem 2rem
+    outline none
+    transition all .2s ease
+    background #fff url(./search.svg) 0.6rem 0.6rem no-repeat
+    background-size 1.2rem
+
+@media (max-width: $MQMobile)
+  .sb-search2-modal
+    width 300px
+    margin-left calc(100% - 90vw)
+</style>

--- a/docs/.vuepress/components/Navbar.vue
+++ b/docs/.vuepress/components/Navbar.vue
@@ -53,7 +53,7 @@
       <!-- Added: wkande: This adds the custom Versions component. -->
       <Versions />
 
-      <!-- Added: wkande: Replacement search UI, still uses Vuepress logic. -->
+      <!-- Added: wkande: Replacement search UI. -->
       <search-SearchBoxBtn2 />
 
       <!--AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" /-->

--- a/docs/.vuepress/components/search/SearchBox2.vue
+++ b/docs/.vuepress/components/search/SearchBox2.vue
@@ -1,3 +1,7 @@
+<!--
+Possible text highlighting: https://x-team.com/blog/highlight-text-vue-regex/
+-->
+
 <template>
   <div
     class="sb-search2-modal"
@@ -29,8 +33,6 @@
 import Vue from 'vue';
 import vClickOutside from 'v-click-outside';
 Vue.use(vClickOutside);
-
-import matchQuery from './match-query';
 
 /* global SEARCH_MAX_SUGGESTIONS, SEARCH_PATHS, SEARCH_HOTKEYS */
 export default {
@@ -65,30 +67,45 @@ export default {
         this.$site.themeConfig.searchMaxSuggestions || SEARCH_MAX_SUGGESTIONS;
 
       const res = [];
+      const words = query.split(' ');
+
       for (let i = 0; i < pages.length; i++) {
         if (res.length >= max) break;
         const p = pages[i];
-
-        // Filter by the path in "p"
+        // Filters by the path in "p", current doc set only
         if (!this.filterByPath(p)) {
           continue;
         }
 
-        if (matchQuery(query, p)) {
-          res.push(p);
-        } else if (p.headers) {
-          for (let j = 0; j < p.headers.length; j++) {
-            if (res.length >= max) break;
-            const h = p.headers[j];
-            if (h.title && matchQuery(query, p, h.title)) {
-              res.push(
-                Object.assign({}, p, {
+        words.some(checkTitle);
+        words.some(checkHeaders);
+
+        // Does the title contain any words (OR)
+        function checkTitle(word) {
+          if (p.title.toLowerCase().indexOf(word.toLowerCase()) > -1) {
+            res.push({
+              level: 0,
+              path: p.path,
+              folder: p.frontmatter.folder,
+              pageTitle: p.title,
+            });
+          }
+        }
+
+        // Do the headers contain any words (OR)
+        function checkHeaders(word) {
+          if (p.headers) {
+            p.headers.forEach((h) => {
+              if (h.title.toLowerCase().indexOf(word.toLowerCase()) > -1) {
+                res.push({
+                  level: h.level,
                   path: p.path + '#' + h.slug,
-                  folder: p.folder,
-                  header: h,
-                })
-              );
-            }
+                  folder: p.frontmatter.folder,
+                  headerTitle: h.title,
+                  pageTitle: p.title,
+                });
+              }
+            });
           }
         }
       }
@@ -119,7 +136,7 @@ export default {
       }
     },
     filterByPath(p) {
-      // Only allow the search to show items found in hte current doc set
+      // Only allow the search to show items found in the current doc set
       if (p.regularPath.indexOf(this.currentDocSetWithVersion) === 0) {
         return true;
       }

--- a/docs/.vuepress/components/search/SearchBoxBtn2.vue
+++ b/docs/.vuepress/components/search/SearchBoxBtn2.vue
@@ -1,12 +1,12 @@
 <!--
-Parent of VersionsModal.vue. Opens a modal of user version selections.
+Parent of SearchBox2.vue. Opens a search modal.
 
-- Opens a modal passing versions list to modal and env (development or production)
+- Opens a modal passing.
 - Receives emit message from child component to close modal (@clicked="onChildClick")
 -->
 
 <template>
-  <span>
+  <span v-show="showSearchIcon">
     <button
       class="search2-btn"
       @click="openModal"
@@ -23,7 +23,6 @@ Parent of VersionsModal.vue. Opens a modal of user version selections.
 </template>
 
 <script>
-import { env, versions, versionsOis } from '../../config.js';
 import SearchBox2 from './SearchBox2';
 
 export default {
@@ -32,13 +31,8 @@ export default {
     SearchBox2,
   },
   data: () => ({
-    environment: env,
     showModal: false,
-    versions: versions,
-    versionsOis: versionsOis,
-    workingVersion: null,
-    showMenu: 'none',
-    versionDisplay: '',
+    showSearchIcon: false,
   }),
   methods: {
     openModal() {
@@ -53,7 +47,10 @@ export default {
     $route($event) {},
   },
   mounted() {
-    this.$nextTick(function () {});
+    this.$nextTick(function () {
+      // If not the landing page show the search icon.
+      if (this.$route.path !== '/') this.showSearchIcon = true;
+    });
   },
 };
 </script>

--- a/docs/.vuepress/components/search/SearchBoxList2.vue
+++ b/docs/.vuepress/components/search/SearchBoxList2.vue
@@ -9,13 +9,24 @@
         @mouseenter="focus(i)"
       >
         <a href="javascript:void(0)" @click="go(s.path)">
-          <div class="ls-page-folder" v-if="s.frontmatter.folder">
-            <span style="font-size: x-small">📂</span>
-            {{ s.frontmatter.folder }}
+          <!-- Has folder -->
+          <div v-if="s.folder">
+            <div class="ls-page-folder">
+              <span style="font-size: x-small">📂</span>
+              {{ s.folder }}
+            </div>
+            <div class="ls-page-title">└&nbsp;{{ s.pageTitle }}</div>
+            <div v-if="s.headerTitle" class="ls-header">
+              └&nbsp;#&nbsp;{{ s.headerTitle }}
+            </div>
           </div>
-          <div class="ls-page-title">{{ s.title }}</div>
-          <div v-if="s.header" class="ls-header">
-            {{ s.header.title }}
+
+          <!-- No folder -->
+          <div v-if="!s.folder">
+            <div class="ls-page-title">{{ s.pageTitle }}</div>
+            <div v-if="s.headerTitle" class="ls-header-no-folder">
+              └&nbsp;#&nbsp;{{ s.headerTitle }}
+            </div>
           </div>
         </a>
       </li>
@@ -93,12 +104,18 @@ export default {
         font-weight 600
       .ls-page-title
         font-size 0.8em
-        font-weight 500
+        font-weight 600
+        margin-left:2px
 
       .ls-header
         font-size 0.7em
         font-weight 400
+        margin-left:17px
 
+      .ls-header-no-folder
+        font-size 0.7em
+        font-weight 400
+        margin-left:1px
 
     &.focused
       background-color #f3f4f5

--- a/docs/airnode/v0.5/README.md
+++ b/docs/airnode/v0.5/README.md
@@ -1,8 +1,9 @@
 ---
 title: The Airnode
+folder: Introduction
 ---
 
-<TitleSpan>Introduction</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/README.md
+++ b/docs/airnode/v0.5/concepts/README.md
@@ -1,8 +1,9 @@
 ---
 title: Request-Response Protocol
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/airnode-auth.md
+++ b/docs/airnode/v0.5/concepts/airnode-auth.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode Authentication
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/airnode.md
+++ b/docs/airnode/v0.5/concepts/airnode.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/authorization.md
+++ b/docs/airnode/v0.5/concepts/authorization.md
@@ -1,8 +1,9 @@
 ---
 title: Authorizers
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/chain-providers.md
+++ b/docs/airnode/v0.5/concepts/chain-providers.md
@@ -1,8 +1,9 @@
 ---
 title: Chain Providers
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/endpoint.md
+++ b/docs/airnode/v0.5/concepts/endpoint.md
@@ -1,8 +1,9 @@
 ---
 title: Endpoint
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/relay-meta-auth.md
+++ b/docs/airnode/v0.5/concepts/relay-meta-auth.md
@@ -1,8 +1,9 @@
 ---
 title: Relayed Meta Data Authentication
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/request.md
+++ b/docs/airnode/v0.5/concepts/request.md
@@ -1,8 +1,9 @@
 ---
 title: Request
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/requester.md
+++ b/docs/airnode/v0.5/concepts/requester.md
@@ -1,8 +1,9 @@
 ---
 title: Requester
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/sponsor.md
+++ b/docs/airnode/v0.5/concepts/sponsor.md
@@ -1,8 +1,9 @@
 ---
 title: Sponsor
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/concepts/template.md
+++ b/docs/airnode/v0.5/concepts/template.md
@@ -1,8 +1,9 @@
 ---
 title: Template
+folder: Concepts and Definitions
 ---
 
-<TitleSpan>Concepts and Definitions</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-developers/README.md
+++ b/docs/airnode/v0.5/grp-developers/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: Developers
 ---
 
-<TitleSpan>Developers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-developers/call-an-airnode.md
+++ b/docs/airnode/v0.5/grp-developers/call-an-airnode.md
@@ -1,8 +1,9 @@
 ---
 title: Calling an Airnode
+folder: Developers
 ---
 
-<TitleSpan>Developers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-developers/fees.md
+++ b/docs/airnode/v0.5/grp-developers/fees.md
@@ -1,8 +1,9 @@
 ---
 title: Fees
+folder: Developers
 ---
 
-<TitleSpan>Developers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-developers/requesters-sponsors.md
+++ b/docs/airnode/v0.5/grp-developers/requesters-sponsors.md
@@ -1,8 +1,9 @@
 ---
 title: Requesters and Sponsors
+folder: Developers
 ---
 
-<TitleSpan>Developers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-developers/using-templates.md
+++ b/docs/airnode/v0.5/grp-developers/using-templates.md
@@ -1,8 +1,9 @@
 ---
 title: Using Templates
+folder: Developers
 ---
 
-<TitleSpan>Developers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/README.md
+++ b/docs/airnode/v0.5/grp-providers/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: API Providers
 ---
 
-<TitleSpan>API Providers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/airnode/design-philosophy.md
+++ b/docs/airnode/v0.5/grp-providers/airnode/design-philosophy.md
@@ -1,8 +1,9 @@
 ---
 title: Design Philosophy
+folder: API Providers
 ---
 
-<TitleSpan>API Providers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/airnode/ethereum-providers.md
+++ b/docs/airnode/v0.5/grp-providers/airnode/ethereum-providers.md
@@ -1,8 +1,9 @@
 ---
 title: Ethereum providers
+folder: API Providers
 ---
 
-<TitleSpan>API Providers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/airnode/implementation.md
+++ b/docs/airnode/v0.5/grp-providers/airnode/implementation.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode implementation
+folder: API Providers
 ---
 
-<TitleSpan>API Providers</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/docker/README.md
+++ b/docs/airnode/v0.5/grp-providers/docker/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: API Providers > Docker Images
 ---
 
-<TitleSpan>Docker Images</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/docker/admin-cli-image.md
+++ b/docs/airnode/v0.5/grp-providers/docker/admin-cli-image.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode Admin CLI Image
+folder: API Providers > Docker Images
 ---
 
-<TitleSpan>Docker Images</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.5/grp-providers/docker/client-image.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode Client Image
+folder: API Providers > Docker Images
 ---
 
-<TitleSpan>Docker Images</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.5/grp-providers/docker/deployer-image.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode Deployer Image
+folder: API Providers > Docker Images
 ---
 
-<TitleSpan>Docker Images</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/README.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/README.md
@@ -1,8 +1,9 @@
 ---
 title: Getting Started
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/api-integration.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/api-integration.md
@@ -1,8 +1,9 @@
 ---
 title: API Integration
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/api-security.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/api-security.md
@@ -1,8 +1,9 @@
 ---
 title: API Security
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/apply-auth.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/apply-auth.md
@@ -1,8 +1,9 @@
 ---
 title: Using Authorizers (optional)
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -1,8 +1,9 @@
 ---
 title: Configuring Airnode
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -1,8 +1,9 @@
 ---
 title: Deploying Airnode
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/heartbeat.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/heartbeat.md
@@ -1,8 +1,9 @@
 ---
 title: Heartbeat (optional)
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
+++ b/docs/airnode/v0.5/grp-providers/guides/build-an-airnode/http-gateways.md
@@ -1,8 +1,9 @@
 ---
 title: HTTP Gateways (optional)
+folder: API Providers > Build an Airnode
 ---
 
-<TitleSpan>Build an Airnode</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: API Providers > Tutorials
 ---
 
-<TitleSpan>Tutorials</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -1,8 +1,9 @@
 ---
 title: Instructions
+folder: API Providers > Tutorials > Quick Deploy AWS
 ---
 
-<TitleSpan>Quick Deploy AWS</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/aws-env.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/aws-env.md
@@ -1,8 +1,9 @@
 ---
 title: aws.env
+folder: API Providers > Tutorials > Quick Deploy AWS
 ---
 
-<TitleSpan>Quick Deploy AWS</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/config-json.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: API Providers > Tutorials > Quick Deploy AWS
 ---
 
-<TitleSpan>Quick Deploy AWS</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/secrets-env.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-aws/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: API Providers > Tutorials > Quick Deploy AWS
 ---
 
-<TitleSpan>Quick Deploy AWS</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/README.md
@@ -1,8 +1,9 @@
 ---
 title: Instructions
+folder: API Providers > Tutorials > Quick Deploy Container
 ---
 
-<TitleSpan>Quick Deploy Container</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/config-json.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: API Providers > Tutorials > Quick Deploy Container
 ---
 
-<TitleSpan>Quick Deploy Container</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/secrets-env.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-container/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: API Providers > Tutorials > Quick Deploy Container
 ---
 
-<TitleSpan>Quick Deploy Container</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -1,8 +1,9 @@
 ---
 title: Instructions
+folder: API Providers > Tutorials > Quick Deploy GCP
 ---
 
-<TitleSpan>Quick Deploy GCP</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/config-json.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: API Providers > Tutorials > Quick Deploy GCP
 ---
 
-<TitleSpan>Quick Deploy GCP</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/secrets-env.md
+++ b/docs/airnode/v0.5/grp-providers/tutorial/quick-deploy-gcp/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: API Providers > Tutorials > Quick Deploy GCP
 ---
 
-<TitleSpan>Quick Deploy GCP</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/introduction/why-use-airnode.md
+++ b/docs/airnode/v0.5/introduction/why-use-airnode.md
@@ -1,8 +1,9 @@
 ---
 title: Why use Airnode?
+folder: Introduction
 ---
 
-<TitleSpan>Introduction</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/airnode-addresses.md
+++ b/docs/airnode/v0.5/reference/airnode-addresses.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode Contract Addresses
+folder: Reference
 ---
 
-<TitleSpan>Reference</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/cloud-resources.md
+++ b/docs/airnode/v0.5/reference/cloud-resources.md
@@ -1,8 +1,9 @@
 ---
 title: Cloud Resources
+folder: Reference
 ---
 
-<TitleSpan>Reference</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/deployment-files/README.md
+++ b/docs/airnode/v0.5/reference/deployment-files/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: Reference > Deployment Files
 ---
 
-<TitleSpan>Deployment Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/deployment-files/aws-env.md
+++ b/docs/airnode/v0.5/reference/deployment-files/aws-env.md
@@ -1,8 +1,9 @@
 ---
 title: aws.env
+folder: Reference > Deployment Files
 ---
 
-<TitleSpan>Deployment Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.5/reference/deployment-files/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: Reference > Deployment Files
 ---
 
-<TitleSpan>Deployment Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/deployment-files/receipt-json.md
+++ b/docs/airnode/v0.5/reference/deployment-files/receipt-json.md
@@ -1,8 +1,9 @@
 ---
 title: receipt.json
+folder: Reference > Deployment Files
 ---
 
-<TitleSpan>Deployment Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/deployment-files/secrets-env.md
+++ b/docs/airnode/v0.5/reference/deployment-files/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: Reference > Deployment Files
 ---
 
-<TitleSpan>Deployment Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/examples/aws-env.md
+++ b/docs/airnode/v0.5/reference/examples/aws-env.md
@@ -1,8 +1,9 @@
 ---
 title: aws.env
+folder: Reference > Example Files
 ---
 
-<TitleSpan>Example Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/examples/config-json.md
+++ b/docs/airnode/v0.5/reference/examples/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: Reference > Example Files
 ---
 
-<TitleSpan>Example Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/examples/secrets-env.md
+++ b/docs/airnode/v0.5/reference/examples/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: Reference > Example Files
 ---
 
-<TitleSpan>Example Files</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/README.md
+++ b/docs/airnode/v0.5/reference/packages/README.md
@@ -1,8 +1,9 @@
 ---
 title: Overview
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/adapter.md
+++ b/docs/airnode/v0.5/reference/packages/adapter.md
@@ -1,8 +1,9 @@
 ---
 title: Adapter
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.5/reference/packages/admin-cli.md
@@ -1,8 +1,9 @@
 ---
 title: Admin CLI
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/airnode-abi.md
+++ b/docs/airnode/v0.5/reference/packages/airnode-abi.md
@@ -1,8 +1,9 @@
 ---
 title: ABI
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/deployer.md
+++ b/docs/airnode/v0.5/reference/packages/deployer.md
@@ -1,8 +1,9 @@
 ---
 title: Deployer
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/packages/validator.md
+++ b/docs/airnode/v0.5/reference/packages/validator.md
@@ -1,8 +1,9 @@
 ---
 title: Validator
+folder: Reference > Packages
 ---
 
-<TitleSpan>Packages</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/specifications/airnode-abi-specifications.md
+++ b/docs/airnode/v0.5/reference/specifications/airnode-abi-specifications.md
@@ -1,8 +1,9 @@
 ---
 title: Airnode ABI Specification
+folder: Reference > Specifications
 ---
 
-<TitleSpan>Specifications</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/specifications/ois.md
+++ b/docs/airnode/v0.5/reference/specifications/ois.md
@@ -1,8 +1,9 @@
 ---
 title: Oracle Integration Specifications (OIS)
+folder: Reference > Specifications
 ---
 
-<TitleSpan>Specifications</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/specifications/reserved-parameters.md
+++ b/docs/airnode/v0.5/reference/specifications/reserved-parameters.md
@@ -1,8 +1,9 @@
 ---
 title: Reserved Parameters
+folder: Reference > Specifications
 ---
 
-<TitleSpan>Specifications</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/templates/aws-env.md
+++ b/docs/airnode/v0.5/reference/templates/aws-env.md
@@ -1,8 +1,9 @@
 ---
 title: aws.env
+folder: Reference > Templates
 ---
 
-<TitleSpan>Templates</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/templates/config-json.md
+++ b/docs/airnode/v0.5/reference/templates/config-json.md
@@ -1,8 +1,9 @@
 ---
 title: config.json
+folder: Reference > Templates
 ---
 
-<TitleSpan>Templates</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/templates/ois-json.md
+++ b/docs/airnode/v0.5/reference/templates/ois-json.md
@@ -1,8 +1,9 @@
 ---
 title: OIS Object
+folder: Reference > Templates
 ---
 
-<TitleSpan>Templates</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 

--- a/docs/airnode/v0.5/reference/templates/secrets-env.md
+++ b/docs/airnode/v0.5/reference/templates/secrets-env.md
@@ -1,8 +1,9 @@
 ---
 title: secrets.env
+folder: Reference > Templates
 ---
 
-<TitleSpan>Templates</TitleSpan>
+<TitleSpan>{{$frontmatter.folder}}</TitleSpan>
 
 # {{$frontmatter.title}}
 


### PR DESCRIPTION
The `match-query.js` script used by VuePress does not pick up the second occurrence of a filter term when it appears in both the H1 and lower headings (H2, H3, e.t.c). If the term is in multiple headings other than H1, it will find both.

`match-query.js` has been replaced will an easy to understand function that will allow for new features in the future.

The results layout has a minor change.