### PR TITLE
Format Windows code blocks as batch not bash / sh

### DIFF
--- a/docs/airnode/v0.7/grp-developers/requesters-sponsors.md
+++ b/docs/airnode/v0.7/grp-developers/requesters-sponsors.md
@@ -166,7 +166,7 @@ Requester 0x2c...gDER7 sponsored using sponsorAddress 0xF4...dDyu9
 
 ::: tab Windows
 
-```
+```batch
 npx @api3/airnode-admin sponsor-requester ^
   --providerUrl https://ropsten.infura.io/v3/<KEY> ^
   --sponsor-mnemonic "cricket...oppose" ^
@@ -220,7 +220,7 @@ Sponsor wallet address: 0x14D5a34E5a370b9951Fef4f8fbab2b1016D557d9
 
 ::: tab Windows
 
-```bash
+```batch
 npx @api3/airnode-admin derive-sponsor-wallet-address ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1...dF05s ^

--- a/docs/airnode/v0.7/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.7/grp-providers/docker/client-image.md
@@ -53,7 +53,7 @@ $ docker run --volume $(pwd)/config:/app/config ...
 
 ::: tab Windows PowerShell
 
-```sh
+```powershell
 $ tree
 .
 └── config
@@ -66,7 +66,7 @@ $ docker run --volume $(pwd)/config:/app/config ...
 
 ::: tab Windows CMD
 
-```sh
+```batch
 $ tree
 .
 └── config
@@ -104,7 +104,7 @@ docker run --detach \
 
 ::: tab Windows PowerShell
 
-```sh
+```powershell
 docker run --detach \
   --volume $(pwd)/config:/app/config \
   --name airnode \
@@ -115,7 +115,7 @@ docker run --detach \
 
 ::: tab Windows
 
-```sh
+```batch
 docker run --detach ^
   --volume %cd%/config:/app/config ^
   --name airnode ^

--- a/docs/airnode/v0.7/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.7/grp-providers/docker/deployer-image.md
@@ -110,7 +110,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
@@ -141,7 +141,7 @@ docker run -it --rm \
 
 ::: tab Windows
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
@@ -177,7 +177,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/output:/app/output" ^
@@ -207,7 +207,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/output:/app/output" ^

--- a/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.7/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -119,7 +119,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
@@ -152,7 +152,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
@@ -230,7 +230,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/output:/app/output" ^
@@ -260,7 +260,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/output:/app/output" ^

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -164,7 +164,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/config:/app/config" ^
@@ -271,7 +271,7 @@ curl -v \
 
 ::: tab Windows
 
-```sh
+```batch
 curl -v ^
 -X POST ^
 -H "Content-Type: application/json" ^
@@ -326,7 +326,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   --env-file aws.env ^
   -v "%cd%/output:/app/output" ^

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/README.md
@@ -130,7 +130,7 @@ docker run --detach \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run --detach ^
   --volume "%cd%/config:/app/config" ^
   --name quick-deploy-container-airnode ^

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -174,7 +174,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/config:/app/config" ^
@@ -281,7 +281,7 @@ curl -v \
 
 ::: tab Windows
 
-```sh
+```batch
 curl -v ^
 -X POST ^
 -H 'Content-Type: application/json' ^
@@ -333,7 +333,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%/gcp.json:/app/gcp.json" ^
   -v "%cd%/output:/app/output" ^

--- a/docs/airnode/v0.7/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.7/reference/packages/admin-cli.md
@@ -248,7 +248,7 @@ npx @api3/airnode-admin sponsor-requester \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin sponsor-requester ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -299,7 +299,7 @@ npx @api3/airnode-admin unsponsor-requester \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin unsponsor-requester ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -338,7 +338,7 @@ npx @api3/airnode-admin get-sponsor-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-sponsor-status ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-address 0x9Ec6C4... ^
@@ -378,7 +378,7 @@ npx @api3/airnode-admin derive-sponsor-wallet-address \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-sponsor-wallet-address ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1e0dd... ^
@@ -428,7 +428,7 @@ npx @api3/airnode-admin create-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin create-template ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --mnemonic "nature about salad..." ^
@@ -471,7 +471,7 @@ npx @api3/airnode-admin create-inline-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin create-inline-template ^
   --template-file-path ./template.json
 ```
@@ -503,7 +503,7 @@ npx @api3/airnode-admin get-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-template ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --template-id 0x8d3b9...
@@ -573,7 +573,7 @@ npx @api3/airnode-admin request-withdrawal \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin request-withdrawal ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -611,7 +611,7 @@ npx @api3/airnode-admin check-withdrawal-request \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin check-withdrawal-request ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --withdrawal-request-id 0x011d1b...
@@ -647,7 +647,7 @@ npx @api3/airnode-admin verify-airnode-xpub \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin verify-airnode-xpub ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1e0dd...
@@ -691,7 +691,7 @@ npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about sal
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about salad..."
 ```
 
@@ -726,7 +726,7 @@ npx @api3/airnode-admin derive-endpoint-id \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-endpoint-id ^
   --ois-title "My OIS title..." ^
   --endpoint-name "My endpoint name..."
@@ -771,7 +771,7 @@ npx @api3/airnode-admin derive-airnode-address \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-airnode-address ^
 --airnode-mnemonic "cricket among ..."
 ```
@@ -847,7 +847,7 @@ npx @api3/airnode-admin set-whitelist-expiration \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin set-whitelist-expiration ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -907,7 +907,7 @@ npx @api3/airnode-admin extend-whitelist-expiration \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin extend-whitelist-expiration ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -970,7 +970,7 @@ npx @api3/airnode-admin set-indefinite-whitelist-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin set-indefinite-whitelist-status ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -1011,7 +1011,7 @@ npx @api3/airnode-admin get-whitelist-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-whitelist-status ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --endpoint-id 0xda088e2d94... ^
@@ -1051,7 +1051,7 @@ npx @api3/airnode-admin is-requester-whitelisted \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin is-requester-whitelisted ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --requester-authorizer-with-airnode 0xDc64a1... ^

--- a/docs/airnode/v0.8/grp-developers/requesters-sponsors.md
+++ b/docs/airnode/v0.8/grp-developers/requesters-sponsors.md
@@ -166,7 +166,7 @@ Requester 0x2c...gDER7 sponsored using sponsorAddress 0xF4...dDyu9
 
 ::: tab Windows
 
-```
+```batch
 npx @api3/airnode-admin sponsor-requester ^
   --providerUrl https://ropsten.infura.io/v3/<KEY> ^
   --sponsor-mnemonic "cricket...oppose" ^
@@ -220,7 +220,7 @@ Sponsor wallet address: 0x14D5a34E5a370b9951Fef4f8fbab2b1016D557d9
 
 ::: tab Windows
 
-```bash
+```batch
 npx @api3/airnode-admin derive-sponsor-wallet-address ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1...dF05s ^

--- a/docs/airnode/v0.8/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/client-image.md
@@ -52,7 +52,7 @@ $ docker run --volume $(pwd):/app/config ...
 
 ::: tab Windows PowerShell
 
-```sh
+```powershell
 $ tree
 .
 ├── config.json
@@ -64,7 +64,7 @@ $ docker run --volume $(pwd):/app/config ...
 
 ::: tab Windows CMD
 
-```sh
+```batch
 $ tree
 .
 ├── config.json
@@ -101,7 +101,7 @@ docker run --detach \
 
 ::: tab Windows PowerShell
 
-```sh
+```powershell
 docker run --detach \
   --volume $(pwd):/app/config \
   --name airnode \
@@ -112,7 +112,7 @@ docker run --detach \
 
 ::: tab Windows
 
-```sh
+```batch
 docker run --detach ^
   --volume %cd%:/app/config ^
   --name airnode ^

--- a/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.8/grp-providers/docker/deployer-image.md
@@ -97,7 +97,7 @@ docker run -it --rm \
 
 ::: tab Windows
 
-```sh
+```batch
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
@@ -149,7 +149,7 @@ docker run -it --rm \
 
 ::: tab Windows
 
-```sh
+```batch
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
@@ -206,7 +206,7 @@ docker run -it --rm \
 
 ::: tab Windows
 
-```sh
+```batch
 #For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "$(pwd):/app/config" ^

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -111,7 +111,7 @@ docker run -it --rm \
 
 ::: tab Windows
 
-```sh
+```batch
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -159,7 +159,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
   api3/airnode-deployer:0.8.0 deploy
@@ -265,7 +265,7 @@ curl -v \
 
 ::: tab Windows
 
-```sh
+```batch
 curl -v ^
 -X POST ^
 -H "Content-Type: application/json" ^
@@ -316,7 +316,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/README.md
@@ -128,7 +128,7 @@ docker run --detach \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run --detach ^
   --volume "%cd%:/app/config" ^
   --name quick-deploy-container-airnode ^

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -170,7 +170,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
   api3/airnode-deployer:0.8.0 deploy
@@ -276,7 +276,7 @@ curl -v \
 
 ::: tab Windows
 
-```sh
+```batch
 curl -v ^
 -X POST ^
 -H 'Content-Type: application/json' ^
@@ -327,7 +327,7 @@ docker run -it --rm \
 
 For Windows, use CMD (and not PowerShell).
 
-```sh
+```batch
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
   api3/airnode-deployer:0.8.0 remove-with-receipt

--- a/docs/airnode/v0.8/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.8/reference/packages/admin-cli.md
@@ -248,7 +248,7 @@ npx @api3/airnode-admin sponsor-requester \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin sponsor-requester ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -299,7 +299,7 @@ npx @api3/airnode-admin unsponsor-requester \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin unsponsor-requester ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -338,7 +338,7 @@ npx @api3/airnode-admin get-sponsor-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-sponsor-status ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-address 0x9Ec6C4... ^
@@ -378,7 +378,7 @@ npx @api3/airnode-admin derive-sponsor-wallet-address \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-sponsor-wallet-address ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1e0dd... ^
@@ -428,7 +428,7 @@ npx @api3/airnode-admin create-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin create-template ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --mnemonic "nature about salad..." ^
@@ -471,7 +471,7 @@ npx @api3/airnode-admin create-inline-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin create-inline-template ^
   --template-file-path ./template.json
 ```
@@ -503,7 +503,7 @@ npx @api3/airnode-admin get-template \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-template ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --template-id 0x8d3b9...
@@ -573,7 +573,7 @@ npx @api3/airnode-admin request-withdrawal \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin request-withdrawal ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --sponsor-mnemonic "nature about salad..." ^
@@ -611,7 +611,7 @@ npx @api3/airnode-admin check-withdrawal-request \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin check-withdrawal-request ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --withdrawal-request-id 0x011d1b...
@@ -647,7 +647,7 @@ npx @api3/airnode-admin verify-airnode-xpub \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin verify-airnode-xpub ^
   --airnode-xpub xpub6CUGRUo... ^
   --airnode-address 0xe1e0dd...
@@ -691,7 +691,7 @@ npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about sal
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about salad..."
 ```
 
@@ -726,7 +726,7 @@ npx @api3/airnode-admin derive-endpoint-id \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-endpoint-id ^
   --ois-title "My OIS title..." ^
   --endpoint-name "My endpoint name..."
@@ -771,7 +771,7 @@ npx @api3/airnode-admin derive-airnode-address \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin derive-airnode-address ^
 --airnode-mnemonic "cricket among ..."
 ```
@@ -847,7 +847,7 @@ npx @api3/airnode-admin set-whitelist-expiration \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin set-whitelist-expiration ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -907,7 +907,7 @@ npx @api3/airnode-admin extend-whitelist-expiration \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin extend-whitelist-expiration ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -970,7 +970,7 @@ npx @api3/airnode-admin set-indefinite-whitelist-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin set-indefinite-whitelist-status ^
   --mnemonic "nature about salad..." ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
@@ -1011,7 +1011,7 @@ npx @api3/airnode-admin get-whitelist-status \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin get-whitelist-status ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --endpoint-id 0xda088e2d94... ^
@@ -1051,7 +1051,7 @@ npx @api3/airnode-admin is-requester-whitelisted \
 
 ::: tab Windows
 
-```sh
+```batch
 npx @api3/airnode-admin is-requester-whitelisted ^
   --provider-url https://eth-rinkeby.gateway.pokt.network/v1/lb/<APP_ID> ^
   --requester-authorizer-with-airnode 0xDc64a1... ^


### PR DESCRIPTION
Replaces `sh` and `bash` with `batch` for syntax highlighting of Windows CMD code blocks and with `powershell` for the few Powershell code blocks. Prismjs supported languages [are here](https://prismjs.com/#supported-languages) as a reference.

See the preview site below for how it renders.