### PR TITLE
Bump github-script to v6

### DIFF
--- a/.github/workflows/firebase-deployment.yml
+++ b/.github/workflows/firebase-deployment.yml
@@ -31,7 +31,7 @@ jobs:
           channelId: ${{ steps.get_branch.outputs.branch_name }}
         id: firebase_deploy
 
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v6
         with:
           script: |
             github.rest.repos.createCommitComment({


### PR DESCRIPTION
While this unfortunately doesn't recover the missing PR firebase preview comments, the Action succeeded in [generating the expected commit comment](https://github.com/api3dao/api3-docs/commit/e80d9980f1762f3c2d9b56be9c53c65a41948ed9#commitcomment-80379836) and it's good to keep Actions up-to-date. 