### PR TITLE
Refactor `generate-mnemonic`

### DIFF
--- a/docs/airnode/v0.8/concepts/airnode.md
+++ b/docs/airnode/v0.8/concepts/airnode.md
@@ -66,14 +66,15 @@ npx @api3/airnode-admin derive-airnode-xpub \
 Airnode xpub: xpub6CUGRUo...
 ```
 
-## Admin CLI: `generate-mnemonic`
+## Admin CLI: `generate-airnode-mnemonic`
 
-The [generate-mnemonic](../reference/packages/admin-cli.md#generate-mnemonic)
+The
+[generate-airnode-mnemonic](../reference/packages/admin-cli.md#generate-airnode-mnemonic)
 command is useful because it will generate a mnemonic as well as return the
 `airnodeAddress` and `xpub`.
 
 ```sh
-npx @api3/airnode-admin generate-mnemonic
+npx @api3/airnode-admin generate-airnode-mnemonic
 
 # output
 This mnemonic is created locally on your machine using "ethers.Wallet.createRandom" under the hood.

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/README.md
@@ -110,7 +110,7 @@ Add values for each of the these fields.
 - `AIRNODE_WALLET_MNEMONIC`: Provide the seed phrase (mnemonic) to a digital
   wallet. For the purpose of this demo it does not need eth in it for the
   Rinkeby test network. If you don't have one use the Admin CLI command
-  [generate-mnemonic](../../../reference/packages/admin-cli.md#generate-mnemonic)
+  [generate-airnode-mnemonic](../../../reference/packages/admin-cli.md#generate-airnode-mnemonic)
   to create one or another method you prefer.
 
 - `HTTP_GATEWAY_API_KEY`: Make up an apiKey to authenticate calls to the HTTP

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/README.md
@@ -99,7 +99,7 @@ Add values for each of the these fields.
 - `AIRNODE_WALLET_MNEMONIC`: Provide the seed phrase (mnemonic) to a digital
   wallet. For the purpose of this demo it does not need eth in it for the
   Rinkeby test network. If you don't have one use the Admin CLI command
-  [generate-mnemonic](../../../reference/packages/admin-cli.md#generate-mnemonic)
+  [generate-airnode-mnemonic](../../../reference/packages/admin-cli.md#generate-airnode-mnemonic)
   to create one or another method you prefer.
 
 ## Deploy

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/README.md
@@ -102,7 +102,7 @@ Add values for each of the these fields.
 - `AIRNODE_WALLET_MNEMONIC`: Provide the seed phrase (mnemonic) to a digital
   wallet. For the purpose of this demo it does not need eth in it for the
   Rinkeby test network. If you don't have one use the Admin CLI command
-  [generate-mnemonic](../../../reference/packages/admin-cli.md#generate-mnemonic)
+  [generate-airnode-mnemonic](../../../reference/packages/admin-cli.md#generate-airnode-mnemonic)
   to create one or another method you prefer.
 
 - `PROJECT_ID`: Project ID of your GCP project.

--- a/docs/airnode/v0.8/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.8/reference/packages/admin-cli.md
@@ -665,7 +665,7 @@ Airnode wallet.
 
 - [derive-airnode-xpub](admin-cli.md#derive-airnode-xpub)
 - [derive-endpoint-id](admin-cli.md#derive-endpoint-id)
-- [generate-mnemonic](admin-cli.md#generate-mnemonic)
+- [generate-airnode-mnemonic](admin-cli.md#generate-airnode-mnemonic)
 - [derive-airnode-address](admin-cli.md#derive-airnode-address)
 
 ### `derive-airnode-xpub`
@@ -736,13 +736,23 @@ npx @api3/airnode-admin derive-endpoint-id ^
 
 ::::
 
-### `generate-mnemonic`
+### `generate-airnode-mnemonic`
 
 Generates a unique mnemonic which can be used to create an
 [airnode wallet](../../grp-providers/guides/build-an-airnode/configuring-airnode.md#airnodewalletmnemonic).
 In addition to the mnemonic, this command will also display the corresponding
 [airnode address](../../concepts/airnode.md#airnodeaddress) and its extended
 public key ([xpub](../../concepts/airnode.md#xpub)).
+
+```sh
+npx @api3/airnode-admin generate-airnode-mnemonic
+```
+
+### `generate-mnemonic`
+
+Generates a unique mnemonic which can be used to create a wallet. In addition to
+the mnemonic, this command will also display the corresponding default wallet
+(path:m/44'/60'/0'/0/0) address and its extended public key (xpub).
 
 ```sh
 npx @api3/airnode-admin generate-mnemonic

--- a/docs/airnode/v0.8/reference/packages/admin-cli.md
+++ b/docs/airnode/v0.8/reference/packages/admin-cli.md
@@ -752,7 +752,7 @@ npx @api3/airnode-admin generate-airnode-mnemonic
 
 Generates a unique mnemonic which can be used to create a wallet. In addition to
 the mnemonic, this command will also display the corresponding default wallet
-(path:m/44'/60'/0'/0/0) address and its extended public key (xpub).
+(path:m/44'/60'/0'/0/0) address.
 
 ```sh
 npx @api3/airnode-admin generate-mnemonic


### PR DESCRIPTION
Closes #948 

The idea was to make the output of `generate-mnemonic` more general by not referring to an airnode wallet and also create a new command, `generate-airnode-mnemonic`, with airnode-specific output.