### PR TITLE
update stage names

### DIFF
--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -45,7 +45,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev"
+    "stage": "tutorial-aws"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -41,7 +41,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev"
+    "stage": "tutorial-container"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.6/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -46,7 +46,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev"
+    "stage": "tutorial-gcp"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config/config.json
@@ -45,7 +45,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.7.2",
-    "stage": "dev"
+    "stage": "tutorial-aws"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config/config.json
@@ -41,7 +41,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.7.2",
-    "stage": "dev"
+    "stage": "tutorial-container"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
+++ b/docs/airnode/v0.7/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config/config.json
@@ -46,7 +46,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.7.2",
-    "stage": "dev"
+    "stage": "tutorial-gcp"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-aws/src/quick-deploy-aws/config.json
@@ -73,7 +73,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.8.0",
-    "stage": "dev"
+    "stage": "tutorial-aws"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-container/src/quick-deploy-container/config.json
@@ -71,7 +71,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.8.0",
-    "stage": "dev"
+    "stage": "tutorial-container"
   },
   "triggers": {
     "rrp": [

--- a/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config.json
+++ b/docs/airnode/v0.8/grp-providers/tutorial/quick-deploy-gcp/src/quick-deploy-gcp/config.json
@@ -74,7 +74,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.8.0",
-    "stage": "dev"
+    "stage": "tutorial-gcp"
   },
   "triggers": {
     "rrp": [


### PR DESCRIPTION
Closes #968 

Stage names changes due to GCP issue of hanging onto resources for storage bucket on olde stage name of `dev`. Having distinct names is a better practice as well.