### PR TITLE
Added AWS disable regions note:

### DIFF
--- a/docs/airnode/v0.6/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.6/reference/deployment-files/config-json.md
@@ -268,8 +268,14 @@ you want to run Airnode as a docker container locally
 #### `cloudProvider.region`
 
 (required for AWS and GCP) - The cloud provider region that the node will be
-deployed at. See the cloud provider's documentation for possible values. When
-using GCP, make sure to choose a **region** and not a zone.
+deployed at. See the cloud provider's documentation for possible values. Some
+AWS regions are disabled by default, you must enable them before you can create
+and manage resources, see
+[Enabling a Region](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html).
+When using GCP, make sure to choose a **region** and not a zone. Note that
+transferring a deployment from one region to the other is not trivial (i.e., it
+does not take one command like deployment, but rather three). Therefore, try to
+choose a region and stick to it for this specific deployment.
 
 #### `cloudProvider.disableConcurrencyReservations`
 

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -316,6 +316,9 @@ you want to run Airnode as a docker container locally
 (required for AWS and GCP) - The cloud provider region that the node will be
 deployed at. An example AWS value would be `us-east-1` and an example GCP value
 would be `us-east1`. See the cloud provider's documentation for possible values.
+Some AWS regions are disabled by default, you must enable them before you can
+create and manage resources, see
+[Enabling a Region](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html).
 When using GCP, make sure to choose a **region** and not a zone. Note that
 transferring a deployment from one region to the other is not trivial (i.e., it
 does not take one command like deployment, but rather three). Therefore, try to

--- a/docs/airnode/v0.8/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/config-json.md
@@ -372,13 +372,16 @@ run Airnode as a docker container locally
 #### `cloudProvider.region`
 
 (required:<span style="font-size:small;color:gray">
-`if cloudPrivider.type is AWS or GCP`</span>) - The cloud provider region that
-the node will be deployed at. An example AWS value would be `us-east-1` and an
-example GCP value would be `us-east1`. See the cloud provider's documentation
-for possible values. When using GCP, make sure to choose a **region** and not a
-zone. Note that transferring a deployment from one region to the other is not
-trivial (i.e., it does not take one command like deployment, but rather three).
-Therefore, try to choose a region and stick to it for this specific deployment.
+`if cloudProvider.type is AWS or GCP`</span>) - The cloud provider region that
+the Airnode will be deployed at. An example AWS value would be `us-east-1` and
+an example GCP value would be `us-east1`. See the cloud provider's documentation
+for possible values. Some AWS regions are disabled by default, you must enable
+them before you can create and manage resources, see
+[Enabling a Region](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html).
+When using GCP, make sure to choose a **region** and not a zone. Note that
+transferring a deployment from one region to the other is not trivial (i.e., it
+does not take one command like deployment, but rather three). Therefore, try to
+choose a region and stick to it for this specific deployment.
 
 #### `cloudProvider.disableConcurrencyReservations`
 


### PR DESCRIPTION
Closes #962 
AWS regions are disabled by default, you must enable them before you can create
and manage resources, see
[Enabling a Region](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html).