### PR TITLE
Make simultaneous deployments warning v0.8+ compatible

### DIFF
--- a/docs/.vuepress/components/airnode/WarningSimultaneousDeployments.vue
+++ b/docs/.vuepress/components/airnode/WarningSimultaneousDeployments.vue
@@ -10,10 +10,11 @@ WARNING: Do not place HTML comment lines inside paragraph elements.
   <div class="custom-block warning">
     <p class="custom-block-title">Warning about simultaneous deployments</p>
     <p style="padding-top: 8px">
-      Avoid running multiple deployments simultaneously. Doing so might result
-      in a broken deployment without the option to either fix or remove it. If a
-      deployment fails to remove with the <code>remove</code> command try a
-      <router-link :to="removeLink">Manual Removal</router-link>.
+      Avoid running multiple deployments simultaneously as doing so might result
+      in a broken deployment. If this occurs, the standard removal approach may
+      not succeed and
+      <router-link :to="removeLink">Manual Removal</router-link> may be
+      required.
     </p>
   </div>
 </template>


### PR DESCRIPTION
This change makes the warning compatible with `v0.8` where the `remove` command has been replaced with `remove-with-receipt` and `remove-with-deployment-details`.