### PR TITLE
Remove outdated tx considerations section

### DIFF
--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -87,7 +87,8 @@ exclude = [
   "https://dx.doi.org/10.1063/1.3597793",
   "faucet.egorfine.com",
   "https://developer.offchainlabs.com/docs/arbgas",
-  "localhost:3000"
+  "localhost:3000",
+  "ipfs.fleek.co/ipfs/bafybeifl4prxv75fgumtjh4ovklfkp7zzt7dwkl4xmndv37gtcalwpam2u",
 ]
 
 # Exclude URLs contained in a file from checking

--- a/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -132,18 +132,6 @@ Below is a simple chain array with a single chain provider.
 ],
 ```
 
-#### Considerations: Transaction Options
-
-A number of fields within the `chains` array adjust how transactions are
-handled. Exposing these fields is necessary for Airnode to serve numerous
-disparate `evm` chains. For example, some chains, such as Optimism, do not
-support EIP-1559 transaction pricing, in which case `legacy` should be used for
-`txType`. In cases where gas pricing estimates may be low or transactions are
-processed slowly, either `baseFeeMultiplier`, for legacy transactions, or
-`gasPriceMultiplier`, for EIP-1559 transactions, can be set. The
-[reference section below](#chains-reference) has links to these and other
-relevant fields.
-
 ::: warning Idiosyncrasies
 
 See the dedicated

--- a/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.8/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -132,18 +132,6 @@ Below is a simple chain array with a single chain provider.
 ],
 ```
 
-#### Considerations: Transaction Options
-
-A number of fields within the `chains` array adjust how transactions are
-handled. Exposing these fields is necessary for Airnode to serve numerous
-disparate `evm` chains. For example, some chains, such as Optimism, do not
-support EIP-1559 transaction pricing, in which case `legacy` should be used for
-`txType`. In cases where gas pricing estimates may be low or transactions are
-processed slowly, either `baseFeeMultiplier`, for legacy transactions, or
-`gasPriceMultiplier`, for EIP-1559 transactions, can be set. The
-[reference section below](#chains-reference) has links to these and other
-relevant fields.
-
 ::: warning Idiosyncrasies
 
 See the dedicated

--- a/docs/airnode/v0.9/grp-providers/guides/build-an-airnode/configuring-airnode.md
+++ b/docs/airnode/v0.9/grp-providers/guides/build-an-airnode/configuring-airnode.md
@@ -132,18 +132,6 @@ Below is a simple chain array with a single chain provider.
 ],
 ```
 
-#### Considerations: Transaction Options
-
-A number of fields within the `chains` array adjust how transactions are
-handled. Exposing these fields is necessary for Airnode to serve numerous
-disparate `evm` chains. For example, some chains, such as Optimism, do not
-support EIP-1559 transaction pricing, in which case `legacy` should be used for
-`txType`. In cases where gas pricing estimates may be low or transactions are
-processed slowly, either `baseFeeMultiplier`, for legacy transactions, or
-`gasPriceMultiplier`, for EIP-1559 transactions, can be set. The
-[reference section below](#chains-reference) has links to these and other
-relevant fields.
-
 ::: warning Idiosyncrasies
 
 See the dedicated


### PR DESCRIPTION
The addition of gas price oracle strategies rendered this section obsolete. As one example, `txType` no longer exists.