### PR TITLE
chains[n].authorizers should be an empty object, not an empty array

### DIFF
--- a/docs/airnode/v0.10/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.10/reference/deployment-files/config-json.md
@@ -175,7 +175,7 @@ respective parameters.
 
 (required) - An object containing authorizer types that list authorizer contract
 addresses specifying the authorization patterns that the Airnode should use. An
-empty array would allow-all. See the
+empty object would allow-all. See the
 [Authorization](../../concepts/authorization.md) doc for more information.
 
 ### `authorizations`

--- a/docs/airnode/v0.8/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/config-json.md
@@ -175,7 +175,7 @@ respective parameters.
 
 (required) - An object containing authorizer types that list authorizer contract
 addresses specifying the authorization patterns that the Airnode should use. An
-empty array would allow-all. See the
+empty object would allow-all. See the
 [Authorization](../../concepts/authorization.md) doc for more information.
 
 ### `authorizations`

--- a/docs/airnode/v0.9/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.9/reference/deployment-files/config-json.md
@@ -175,7 +175,7 @@ respective parameters.
 
 (required) - An object containing authorizer types that list authorizer contract
 addresses specifying the authorization patterns that the Airnode should use. An
-empty array would allow-all. See the
+empty object would allow-all. See the
 [Authorization](../../concepts/authorization.md) doc for more information.
 
 ### `authorizations`


### PR DESCRIPTION
I was going through the docs for v0.8 and noticed this issue with `chains[n].authorizers` referring to an empty array, rather than an empty object (the new structure). I hope this covers all of the references