### PR TITLE
Add removal via deployment ID

### DIFF
--- a/docs/airnode/v0.10/grp-providers/docker/deployer-image.md
+++ b/docs/airnode/v0.10/grp-providers/docker/deployer-image.md
@@ -59,8 +59,8 @@ they exist.
 - [deploy](./deployer-image.md#deploy)
 - [list](./deployer-image.md#list)
 - [info](./deployer-image.md#info)
+- [remove](./deployer-image.md#remove)
 - [remove-with-receipt](./deployer-image.md#remove-with-receipt)
-- [remove-with-deployment-details](./deployer-image.md#remove-with-deployment-details)
 
 ### `deploy`
 
@@ -242,13 +242,50 @@ docker run -it --rm ^
 
 ::::
 
+### `remove`
+
+A deployed Airnode can be removed via the
+[remove](../../reference/packages/deployer.md#remove) command. To remove
+Airnode, use the deployment ID from the [list](./deployer-image.md#list) command
+above. Airnode's update history, that can be seen by the
+[info](./deployer-image.md#info) command, will be removed as well. Files for
+cloud provider authentication are needed for the command to run correctly:
+`aws.env` (for AWS) and/or `gcp.json` (for GCP). This is the recommended way to
+remove a deployment, but there are alternatives as described below.
+
+:::: tabs
+
+::: tab Linux/Mac/WSL2
+
+```sh
+docker run -it --rm \
+  -v "$(pwd):/app/config" \
+  api3/airnode-deployer:0.10.0 remove aws2c6ef2b3
+```
+
+:::
+
+::: tab Windows
+
+```batch
+# For Windows, use CMD (not PowerShell).
+docker run -it --rm ^
+  -v "%cd%:/app/config" ^
+  api3/airnode-deployer:0.10.0 remove aws2c6ef2b3
+```
+
+:::
+
+::::
+
 ### `remove-with-receipt`
 
 When an Airnode was deployed using the `deploy` command, a `receipt.json` file
 was created. This file is used to remove the Airnode. The
 [remove-with-receipt](../../reference/packages/deployer.md#remove-with-receipt)
-command (identical for AWS and GCP) is the recommended way to remove a
-deployment, but there are alternatives as described below.
+command is identical for AWS and GCP. Files for cloud provider authentication
+are needed for the command to run correctly: `aws.env` (for AWS) and/or
+`gcp.json` (for GCP).
 
 :::: tabs
 
@@ -275,76 +312,14 @@ docker run -it --rm ^
 
 ::::
 
-### `remove-with-deployment-details`
-
-The
-[remove-with-deployment-details](../../reference/packages/deployer.md#remove-with-deployment-details)
-command is available as an alternative to `remove-with-receipt` and uses the
-Airnode short address and cloud provider specifications. All values, other than
-`airnodeShortAddress`, can be found in
-[config.json](../../reference/deployment-files/config-json.md). Note that
-relative to AWS Airnode removal, GCP Airnode removal requires an additional
-parameter: `projectId`.
-
-- `--airnode-address`: Can be found in the
-  [receipt.json](../../reference/deployment-files/receipt-json.md) file or
-  obtained via Admin CLI command
-  [`derive-airnode-address`](../../reference/packages/admin-cli.html#derive-airnode-address)
-- `--stage`:
-  [nodeSetting.stage](../../reference/deployment-files/config-json.md#stage)
-- `--cloud-provider`:
-  [nodeSetting.cloudProvider.type](../../reference/deployment-files/config-json.md#cloudprovider-type)
-- `--region`:
-  [nodeSetting.cloudProvider.region](../../reference/deployment-files/config-json.md#cloudprovider-region)
-- `--project-id`: (GCP only)
-  [nodeSetting.cloudProvider.projectId](../../reference/deployment-files/config-json.md#cloudprovider-projectid)
-
-Note that the example commands below use placeholder values for a GCP deployment
-that should be replaced.
-
-:::: tabs
-
-::: tab Linux/Mac/WSL2
-
-```sh
-docker run -it --rm \
-  -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.10.0 remove-with-deployment-details \
-  --airnode-address 0xaBd9daAdf32fCd96eE4607bf3d5B31e19a244Cac \
-  --stage dev \
-  --cloud-provider gcp \
-  --projectId myAirnode101 \ ← GCP only
-  --region us-east1
-```
-
-:::
-
-::: tab Windows
-
-```batch
-#For Windows, use CMD (not PowerShell).
-docker run -it --rm ^
-  -v "$(pwd):/app/config" ^
-  api3/airnode-deployer:0.10.0 remove-with-deployment-details ^
-  --airnode-address 0xaBd9daAdf32fCd96eE4607bf3d5B31e19a244Cac ^
-  --stage dev ^
-  --cloud-provider gcp ^
-  --projectId myAirnode101 ^ ← GCP only
-  --region us-east1
-```
-
-:::
-
-::::
-
 ## Manual Removal
 
 Optionally you can remove an Airnode manually though it is highly recommended
-that you do so using the deployer image's `remove-with-receipt` or
-`remove-with-deployment-details` commands. When removing manually, you will need
-the short Airnode address, `airnodeAddressShort` (e.g., `0ab830c`), that is
-included in the element name of AWS and GCP deployed features. Airnode has a
-presence in several areas of both AWS and GCP as listed below.
+that you do so using the deployer image's `remove` or `remove-with-receipt`
+commands. When removing manually, you will need the short Airnode address,
+`airnodeAddressShort` (e.g., `0ab830c`), that is included in the element name of
+AWS and GCP deployed features. Airnode has a presence in several areas of both
+AWS and GCP as listed below.
 
 ::: danger Remember
 

--- a/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -140,6 +140,7 @@ deployment was successful or not.
     "xpub": "xpub661MyMwAqRbcGHp9uC7...vbeziJwFHuNs"
   },
   "deployment": {
+    "deploymentId": "aws8fd2e911",
     "cloudProvider": {
       "type": "aws",
       "region": "us-east-1"

--- a/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/deploying-airnode.md
+++ b/docs/airnode/v0.10/grp-providers/guides/build-an-airnode/deploying-airnode.md
@@ -173,6 +173,6 @@ requests are made to it.
 ## Removing the Airnode
 
 If you would like to remove a deployed Airnode, see the Docker image commands
-for [remove-with-receipt](../../docker/deployer-image.md#remove-with-receipt) or
-[remove-with-deployment-details](../../docker/deployer-image.md#remove-with-deployment-details)
+for [remove](../../docker/deployer-image.md#remove) or
+[remove-with-receipt](../../docker/deployer-image.md#remove-with-receipt)
 instructions.

--- a/docs/airnode/v0.10/reference/deployment-files/receipt-json.md
+++ b/docs/airnode/v0.10/reference/deployment-files/receipt-json.md
@@ -41,6 +41,7 @@ not generated for client deployments (deploying to a Docker container).
     "airnodeXpub": "xpub6C8tvRgYkjNVaGMtpyZf4deBcUQHf7vgWUraVxY6gYiZhBYbPkFkLLWJzUUeVFdkKpVtatmXHX8kB76xgfmTpVZWbVWdq1rneaAY6a8RtbY"
   },
   "deployment": {
+    "deploymentId": "awsef86dfad",
     "cloudProvider": {
       "type": "aws",
       "region": "us-east-1",
@@ -66,6 +67,7 @@ not generated for client deployments (deploying to a Docker container).
     "airnodeXpub": "xpub6C6wfzZ8EptS8Ti2xZgukJFWkgBcFY2ygU4BDTTGtR2GmX3vvrx3YFat3i1XLfwvhtiCEty1GZnV1MSCKBBt7uYKBbrHaqWvP623w9jUNhW"
   },
   "deployment": {
+    "deploymentId": "gcpbecf1982",
     "cloudProvider": {
       "type": "gcp",
       "region": "us-east4",

--- a/docs/airnode/v0.10/reference/packages/deployer.md
+++ b/docs/airnode/v0.10/reference/packages/deployer.md
@@ -215,19 +215,28 @@ airnode-deployer info aws2c6ef2b3
 
 An Airnode can be removed in two different ways:
 
-- **Best:** With `remove-with-receipt`, which uses the deployment receipt
+- **Best:** With `remove`, which uses the deployment ID found either in the
+  [deployment receipt file](../../reference/deployment-files/receipt-json.md) or
+  via the `list` command.
+- **Alternate:** With `remove-with-receipt`, which uses the deployment receipt
   created when the Airnode was deployed.
-- **Alternate:** With `remove-with-deployment-details`, which uses the Airnode
-  address and cloud provider specifications. The Airnode adress can be found in
-  the [receipt.json](../../reference/deployment-files/receipt-json.md) file or
-  obtained via Admin CLI command
-  [`derive-airnode-address`](../../reference/packages/admin-cli.html#derive-airnode-address).
-  The other values can be found in `config.json`.
-  - `nodeSetting.cloudProvider.type`
-  - `nodeSetting.cloudProvider.region`
-  - <code style="overflow-wrap: break-word;">nodeSetting.cloudProvider.projectId</code>
-    (GCP only)
-  - `nodeSetting.stage`
+
+#### remove
+
+```bash
+# Removes a deployed Airnode instance
+
+Positionals:
+  deployment-id  ID of the deployment (from 'list' command)                                          [string] [required]
+
+Options:
+  --version  Show version number                                                                               [boolean]
+  --debug    Run in debug mode                                                                [boolean] [default: false]
+  --help     Show help                                                                                         [boolean]
+
+# Example
+airnode-deployer remove aws2c6ef2b3
+```
 
 #### remove-with-receipt
 
@@ -245,23 +254,4 @@ airnode-deployer remove-with-receipt
 
 # Advanced example specifying the receipt file location
 airnode-deployer remove-with-receipt --receipt config/receipt.json
-```
-
-#### remove-with-deployment-details
-
-```bash
-# Removes a deployed Airnode instance.
-
-Options:
-      --version                Show version number                                                             [boolean]
-      --debug                  Run in debug mode                                              [boolean] [default: false]
-      --help                   Show help                                                                       [boolean]
-  -a, --airnode-address        Airnode Address                                                                  [string]
-  -s, --stage                  Stage (environment)                                                              [string]
-  -c, --cloud-provider         Cloud provider                                                    [choices: "aws", "gcp"]
-  -e, --region                 Region                                                                           [string]
-  -p, --project-id             Project ID (GCP only)                                                            [string]
-
-# Example
-airnode-deployer remove-with-deployment-details --airnode-address 0xaBd9daAdf32fCd96eE4607bf3d5B31e19a244Cac --stage dev --cloud-provider aws --region us-east-1
 ```


### PR DESCRIPTION
Close #1064

I updated the docs so the new `remove` command is the preferred way to remove Airnodes. Just want to double-check with @bbenligiray that this was the intention.