### PR TITLE
Remove ropsten, rinkeby, kovan from chains

### DIFF
--- a/docs/qrng/reference/chains.md
+++ b/docs/qrng/reference/chains.md
@@ -27,10 +27,7 @@ to not break as well.
 <!-- prettier-ignore -->
 | Network   | Chain ID | `AirnodeRrpV0` Address                     | `minConfirmations` |
 | --------- | -------- | ------------------------------------------ | ------------------ |
-| <ChainName chainId="3"/>   | 3        | <span style="white-space: nowrap;">0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd <CopyIcon text="0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"/></span> | 1                  |
-| <ChainName chainId="4"/>   | 4        | 0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd <CopyIcon text="0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"/> | 1                  |
 | <ChainName chainId="5"/>    | 5        | 0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd <CopyIcon text="0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"/> | 1                  |
-| <ChainName chainId="42"/>     | 42       | 0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd <CopyIcon text="0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"/> | 1                  |
 | <ChainName chainId="1"/>   | 1        | 0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd <CopyIcon text="0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"/> | 6                  |
 | <ChainName chainId="42161"/>  | 42161    | 0xb015ACeEdD478fc497A798Ab45fcED8BdEd08924 <CopyIcon text="0xb015ACeEdD478fc497A798Ab45fcED8BdEd08924"/> | 25                 |
 | <ChainName chainId="43114"/> | 43114    | 0xC02Ea0f403d5f3D45a4F1d0d817e7A2601346c9E <CopyIcon text="0xC02Ea0f403d5f3D45a4F1d0d817e7A2601346c9E"/> | 25                 |


### PR DESCRIPTION
QRNG no longer responds to ropsten, rinkeby, kovan requests so we should remove these. We can't add sepolia here until we have AQN redeploy their Airnode and that is blocked by ChainAPI supporting publicly accessible deployments (it deploys with authorizers by default).