### PR TITLE
Various fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,3 +27,5 @@
 /docs/airnode/v0.3/assets
 /docs/airnode/v0.3/figures
 
+# Beacon-related resources
+/docs/.vuepress/beacons.json

--- a/docs/.vuepress/components/dapis/browsers/DapiList.vue
+++ b/docs/.vuepress/components/dapis/browsers/DapiList.vue
@@ -130,7 +130,7 @@ export default {
         'https://operations-development.s3.amazonaws.com/latest/apis.json'
       );
       for (var provider in response.data) {
-        for (var beacon in response.data[provider].beacons) {
+        for (var beacon in response.data[provider]?.beacons) {
           const id = response.data[provider].beacons[beacon].beaconId;
           this.beacons[id] = response.data[provider].beacons[beacon];
         }

--- a/docs/.vuepress/components/dapis/browsers/DapiList.vue
+++ b/docs/.vuepress/components/dapis/browsers/DapiList.vue
@@ -161,7 +161,7 @@ export default {
           // Future use: not sure how to determine NOT a beacon set.
           let beacons = [];
           // Single beacon
-          if (!beacon.beacons) {
+          if (!beacon?.beacons) {
             beacons.push(beacon);
             //content += beacon.beaconId + '' + beacon.description;
           }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "API3 DAO",
   "license": "MIT",
   "engines": {
-    "node": "^14.19.3"
+    "node": "^14"
   },
   "scripts": {
     "sync:404": "cp docs/.vuepress/components/Sub404.vue node_modules/@vuepress/theme-default/layouts/404.vue",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/api3dao/api3-docs",
   "author": "API3 DAO",
   "license": "MIT",
+  "engines": {
+    "node": "^14.19.3"
+  },
   "scripts": {
     "sync:404": "cp docs/.vuepress/components/Sub404.vue node_modules/@vuepress/theme-default/layouts/404.vue",
     "sync:navbar": "cp docs/.vuepress/components/Navbar.vue node_modules/@vuepress/theme-default/components/Navbar.vue",


### PR DESCRIPTION
This PR adds the safe navigation to the code that loads beacons, thereby preventing an error for empty providers.
This PR also adds the `engines` config field to `package.json`, which prevents someone with NodeJS 16 from trying to build this (it will fail to build).
During development the `docs:dev` command downloads resources which `prettier` tries to check for prettiness. This is incorrect behaviour and thus I have added this resource's path to the `.prettierignore`file.