### PR TITLE
Add a list of supported AWS regions for v0.7+

### DIFF
--- a/docs/airnode/v0.10/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.10/reference/deployment-files/config-json.md
@@ -386,17 +386,26 @@ before you can create and manage resources. Note that transferring a deployment
 from one region to the other is not trivial (i.e., it does not take one command
 like deployment, but rather three) and is not advised.
 
-Supported GCP regions:
+##### Supported regions:
 
-- asia-northeast1
-- australia-southeast1
-- europe-west1
-- europe-west2
-- us-central1
-- us-east1
-- us-east4
-- us-west2
-- us-west4
+| GCP                  | AWS            |
+|----------------------|----------------|
+| asia-northeast1      | ap-northeast-1 |
+| australia-southeast1 | ap-northeast-2 |
+| europe-west1         | ap-south-1     |
+| europe-west2         | ap-southeast-1 |
+| us-central1          | ap-southeast-2 |
+| us-east1             | ca-central-1   |
+| us-east4             | eu-central-1   |
+| us-west2             | eu-north-1     |
+| us-west4             | eu-west-1      |
+|                      | eu-west-2      |
+|                      | eu-west-3      |
+|                      | sa-east-1      |
+|                      | us-east-1      |
+|                      | us-east-2      |
+|                      | us-west-1      |
+|                      | us-west-2      |
 
 #### `cloudProvider.disableConcurrencyReservations`
 

--- a/docs/airnode/v0.7/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.7/reference/deployment-files/config-json.md
@@ -324,17 +324,26 @@ before you can create and manage resources. Note that transferring a deployment
 from one region to the other is not trivial (i.e., it does not take one command
 like deployment, but rather three) and is not advised.
 
-Supported GCP regions:
+##### Supported regions:
 
-- asia-northeast1
-- australia-southeast1
-- europe-west1
-- europe-west2
-- us-central1
-- us-east1
-- us-east4
-- us-west2
-- us-west4
+| GCP                  | AWS            |
+|----------------------|----------------|
+| asia-northeast1      | ap-northeast-1 |
+| australia-southeast1 | ap-northeast-2 |
+| europe-west1         | ap-south-1     |
+| europe-west2         | ap-southeast-1 |
+| us-central1          | ap-southeast-2 |
+| us-east1             | ca-central-1   |
+| us-east4             | eu-central-1   |
+| us-west2             | eu-north-1     |
+| us-west4             | eu-west-1      |
+|                      | eu-west-2      |
+|                      | eu-west-3      |
+|                      | sa-east-1      |
+|                      | us-east-1      |
+|                      | us-east-2      |
+|                      | us-west-1      |
+|                      | us-west-2      |
 
 #### `cloudProvider.disableConcurrencyReservations`
 

--- a/docs/airnode/v0.8/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.8/reference/deployment-files/config-json.md
@@ -389,17 +389,26 @@ before you can create and manage resources. Note that transferring a deployment
 from one region to the other is not trivial (i.e., it does not take one command
 like deployment, but rather three) and is not advised.
 
-Supported GCP regions:
+##### Supported regions:
 
-- asia-northeast1
-- australia-southeast1
-- europe-west1
-- europe-west2
-- us-central1
-- us-east1
-- us-east4
-- us-west2
-- us-west4
+| GCP                  | AWS            |
+|----------------------|----------------|
+| asia-northeast1      | ap-northeast-1 |
+| australia-southeast1 | ap-northeast-2 |
+| europe-west1         | ap-south-1     |
+| europe-west2         | ap-southeast-1 |
+| us-central1          | ap-southeast-2 |
+| us-east1             | ca-central-1   |
+| us-east4             | eu-central-1   |
+| us-west2             | eu-north-1     |
+| us-west4             | eu-west-1      |
+|                      | eu-west-2      |
+|                      | eu-west-3      |
+|                      | sa-east-1      |
+|                      | us-east-1      |
+|                      | us-east-2      |
+|                      | us-west-1      |
+|                      | us-west-2      |
 
 #### `cloudProvider.disableConcurrencyReservations`
 

--- a/docs/airnode/v0.9/reference/deployment-files/config-json.md
+++ b/docs/airnode/v0.9/reference/deployment-files/config-json.md
@@ -389,17 +389,26 @@ before you can create and manage resources. Note that transferring a deployment
 from one region to the other is not trivial (i.e., it does not take one command
 like deployment, but rather three) and is not advised.
 
-Supported GCP regions:
+##### Supported regions:
 
-- asia-northeast1
-- australia-southeast1
-- europe-west1
-- europe-west2
-- us-central1
-- us-east1
-- us-east4
-- us-west2
-- us-west4
+| GCP                  | AWS            |
+|----------------------|----------------|
+| asia-northeast1      | ap-northeast-1 |
+| australia-southeast1 | ap-northeast-2 |
+| europe-west1         | ap-south-1     |
+| europe-west2         | ap-southeast-1 |
+| us-central1          | ap-southeast-2 |
+| us-east1             | ca-central-1   |
+| us-east4             | eu-central-1   |
+| us-west2             | eu-north-1     |
+| us-west4             | eu-west-1      |
+|                      | eu-west-2      |
+|                      | eu-west-3      |
+|                      | sa-east-1      |
+|                      | us-east-1      |
+|                      | us-east-2      |
+|                      | us-west-1      |
+|                      | us-west-2      |
 
 #### `cloudProvider.disableConcurrencyReservations`
 


### PR DESCRIPTION
This PR adds a list of supported AWS regions as per Airnode issue [#1429](https://github.com/api3dao/airnode/issues/1429). I formatted these together with GCP regions in a neat table so that this does not occupy too much space. These lists are included in the docsets for v0.7-v0.10.