### PR TITLE
Remove: Stable/USD beacon set

### DIFF
--- a/docs/.vuepress/components/dapis/browsers/DapiList.vue
+++ b/docs/.vuepress/components/dapis/browsers/DapiList.vue
@@ -154,6 +154,10 @@ export default {
         );
         // Construct a dAPI complex object
         for (var dAPI in responseDapis.data) {
+          // Exclude Stable/USD for now
+          if (dAPI === 'Stable/USD') {
+            continue;
+          }
           const datafeedId = responseDapis.data[dAPI]; // Get the dAPI's beacon/setId
           const beacon = this.beacons[datafeedId];
           let content = dAPI + ' ';


### PR DESCRIPTION
This is a beacon set which is actually not production ready. Waiting until the newer API operations that are DB supported.