### PR TITLE
Fix authorizations code example typo

### DIFF
--- a/docs/airnode/v0.10/concepts/authorizations.md
+++ b/docs/airnode/v0.10/concepts/authorizations.md
@@ -59,7 +59,7 @@ The authorizations scheme type is set in
 `chains[n].authorizations.{<authorizationsSchemeType>}` of `config.json`.
 
 ```json
-chains[n].authorizations:{requesterEndpointAuthorizers:{}},
+chains[n].authorizations:{requesterEndpointAuthorizations:{}},
 ```
 
 ## requesterEndpointAuthorizations

--- a/docs/airnode/v0.8/concepts/authorizations.md
+++ b/docs/airnode/v0.8/concepts/authorizations.md
@@ -59,7 +59,7 @@ The authorizations scheme type is set in
 `chains[n].authorizations.{<authorizationsSchemeType>}` of `config.json`.
 
 ```json
-chains[n].authorizations:{requesterEndpointAuthorizers:{}},
+chains[n].authorizations:{requesterEndpointAuthorizations:{}},
 ```
 
 ## requesterEndpointAuthorizations

--- a/docs/airnode/v0.9/concepts/authorizations.md
+++ b/docs/airnode/v0.9/concepts/authorizations.md
@@ -59,7 +59,7 @@ The authorizations scheme type is set in
 `chains[n].authorizations.{<authorizationsSchemeType>}` of `config.json`.
 
 ```json
-chains[n].authorizations:{requesterEndpointAuthorizers:{}},
+chains[n].authorizations:{requesterEndpointAuthorizations:{}},
 ```
 
 ## requesterEndpointAuthorizations


### PR DESCRIPTION
`requesterEndpointAuthorizations` instead of `requesterEndpointAuthorizers` for the authorizations code example.