### PR TITLE
Fix QRNG Maximum Value & Minor Typo

### DIFF
--- a/docs/ois/v1.2/ois.md
+++ b/docs/ois/v1.2/ois.md
@@ -484,8 +484,8 @@ array can be empty. Each object has the following elements:
 - `name`
 - `default`
 - `description *`
-- `require`
-- `example`
+- `required`
+- `example *`
 
 #### 5.5.1. `operationParameter`
 

--- a/docs/qrng/reference/providers.md
+++ b/docs/qrng/reference/providers.md
@@ -29,7 +29,7 @@ endpoint IDs.
 
 - <b>`endpointIdUint256Array`</b>: The Airnode endpoint ID that returns multiple
   random numbers of type `uint256[]`. Takes one parameter named `size` of type
-  `uint256` (maximum value: 1024).
+  `uint256` (maximum value: 512).
 
 ## ANU Quantum Random Numbers
 


### PR DESCRIPTION
I'm working on QRNG migration recently and saw mistake with maximum value of size parameter that QRNG uint256[] endpoint takes. This PR fixes the issue.