### PR TITLE
Remove policies

### DIFF
--- a/docs/ois/v1.0/reserved-parameters.md
+++ b/docs/ois/v1.0/reserved-parameters.md
@@ -22,7 +22,7 @@ A requester can pass request parameters either by referencing a
 argument of the request-making methods of
 [AirnodeRrpV0.sol](/airnode/v0.7/concepts/#airnoderrpv0-sol). In either case,
 these parameters are encoded using the
-[AirnodeRrpV0 ABI](/airnode/v7/reference/specifications/airnode-abi-specifications.md).
+[AirnodeRrpV0 ABI](/airnode/v0.7/reference/specifications/airnode-abi-specifications.md).
 There are two types of parameters which are part of the OIS object:
 
 1. [Endpoint parameters](./ois.md#_5-5-parameters) - Airnode endpoint parameters
@@ -62,7 +62,7 @@ section below.
 Before the API response value is encoded for on chain use, it is parsed and
 converted. The conversion behaviors for any given type is explained in depth in
 the
-[adapter package docs](/airnode/v7/reference/packages/adapter.md#conversion).
+[adapter package docs](/airnode/v.07/reference/packages/adapter.md#conversion).
 
 The converted value is then encoded internally by
 [ethers ABI Coder](https://docs.ethers.io/v5/api/utils/abi/coder/#AbiCoder)
@@ -214,8 +214,8 @@ _times: "100"
 
 the request will be fulfilled with the value `123`. Note that the number gets
 multiplied by `100`, and then gets floored. This is because the result of the
-multiplication is [cast](/airnode/v8/reference/packages/adapter.md) to `int256`
-afterwards.
+multiplication is [cast](/airnode/v0.8/reference/packages/adapter.md) to
+`int256` afterwards.
 
 Make sure to pass the `_times` parameter as string. Airnode will convert this
 string to number internally. You can also pass and empty string `""` to `_times`

--- a/docs/ois/v1.0/reserved-parameters.md
+++ b/docs/ois/v1.0/reserved-parameters.md
@@ -22,7 +22,7 @@ A requester can pass request parameters either by referencing a
 argument of the request-making methods of
 [AirnodeRrpV0.sol](/airnode/v0.7/concepts/#airnoderrpv0-sol). In either case,
 these parameters are encoded using the
-[AirnodeRrpV0 ABI](/airnode/v0.7/reference/specifications/airnode-abi-specifications.md).
+[AirnodeRrpV0 ABI](/airnode/v7/reference/specifications/airnode-abi-specifications.md).
 There are two types of parameters which are part of the OIS object:
 
 1. [Endpoint parameters](./ois.md#_5-5-parameters) - Airnode endpoint parameters
@@ -62,7 +62,7 @@ section below.
 Before the API response value is encoded for on chain use, it is parsed and
 converted. The conversion behaviors for any given type is explained in depth in
 the
-[adapter package docs](/airnode/v0.7/reference/packages/adapter.md#conversion).
+[adapter package docs](/airnode/v7/reference/packages/adapter.md#conversion).
 
 The converted value is then encoded internally by
 [ethers ABI Coder](https://docs.ethers.io/v5/api/utils/abi/coder/#AbiCoder)
@@ -214,8 +214,8 @@ _times: "100"
 
 the request will be fulfilled with the value `123`. Note that the number gets
 multiplied by `100`, and then gets floored. This is because the result of the
-multiplication is [cast](/airnode/v0.7/reference/packages/adapter.md) to
-`int256` afterwards.
+multiplication is [cast](/airnode/v8/reference/packages/adapter.md) to `int256`
+afterwards.
 
 Make sure to pass the `_times` parameter as string. Airnode will convert this
 string to number internally. You can also pass and empty string `""` to `_times`

--- a/docs/ois/v1.1/ois-template.md
+++ b/docs/ois/v1.1/ois-template.md
@@ -21,7 +21,7 @@ they are referencing each other.
 
 The file below is a basic template for OIS. Note, that it might look differently
 for your particular use case. You can also check out the OISes created for our
-[examples in Airnode repository](https://github.com/api3dao/airnode/tree/v0.7/packages/airnode-examples/integrations).
+[examples in Airnode repository](https://github.com/api3dao/airnode/tree/v0.8/packages/airnode-examples/integrations).
 
 ```json
 {

--- a/docs/ois/v1.1/ois.md
+++ b/docs/ois/v1.1/ois.md
@@ -167,7 +167,7 @@ the non-nested application/json content-type is supported.</p>
 
 ### 4.3. `components`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-security.md)
+[<InfoBtnBlue/>](/airnode/v0.8/grp-providers/guides/build-an-airnode/api-security.md)
 (Required) An object where security schemes can be found under
 `securitySchemes.{securitySchemeName}` with the following elements:
 
@@ -413,7 +413,7 @@ respective API operation.-->
 
 ### 5.3. `fixedOperationParameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#fixedoperationparameters)
+[<InfoBtnBlue/>](/airnode/v0.8/grp-providers/guides/build-an-airnode/api-integration.md#fixedoperationparameters)
 (Required) A list of objects specifying the fixed parameters for an API
 operation. While required, the `fixedOperationParameters` array can be empty.
 Each object has the following elements:
@@ -444,7 +444,7 @@ that cannot be overridden by the requester.
 
 ### 5.4. `reservedParameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#reservedparameters)
+[<InfoBtnBlue/>](/airnode/v0.8/grp-providers/guides/build-an-airnode/api-integration.md#reservedparameters)
 (Required) A list of objects that specify reserved Airnode endpoint parameters
 that do not map to any API operation parameters, but are used for special
 purposes by the Airnode. At a minimum, one object must specify the API response
@@ -475,7 +475,7 @@ override the default value.
 
 ### 5.5. `parameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#parameters)
+[<InfoBtnBlue/>](/airnode/v0.8/grp-providers/guides/build-an-airnode/api-integration.md#parameters)
 (Required) A list of objects that specify Airnode endpoint parameters that map
 to an particular API operation's parameters. While required, the `parameters`
 array can be empty. Each object has the following elements:

--- a/docs/ois/v1.2/ois-template.md
+++ b/docs/ois/v1.2/ois-template.md
@@ -21,7 +21,7 @@ they are referencing each other.
 
 The file below is a basic template for OIS. Note, that it might look differently
 for your particular use case. You can also check out the OISes created for our
-[examples in Airnode repository](https://github.com/api3dao/airnode/tree/v0.7/packages/airnode-examples/integrations).
+[examples in Airnode repository](https://github.com/api3dao/airnode/tree/v0.9/packages/airnode-examples/integrations).
 
 ```json
 {

--- a/docs/ois/v1.2/ois.md
+++ b/docs/ois/v1.2/ois.md
@@ -167,7 +167,7 @@ the non-nested application/json content-type is supported.</p>
 
 ### 4.3. `components`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-security.md)
+[<InfoBtnBlue/>](/airnode/v0.9/grp-providers/guides/build-an-airnode/api-security.md)
 (Required) An object where security schemes can be found under
 `securitySchemes.{securitySchemeName}` with the following elements:
 
@@ -413,7 +413,7 @@ respective API operation.-->
 
 ### 5.3. `fixedOperationParameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#fixedoperationparameters)
+[<InfoBtnBlue/>](/airnode/v0.9/grp-providers/guides/build-an-airnode/api-integration.md#fixedoperationparameters)
 (Required) A list of objects specifying the fixed parameters for an API
 operation. While required, the `fixedOperationParameters` array can be empty.
 Each object has the following elements:
@@ -444,7 +444,7 @@ that cannot be overridden by the requester.
 
 ### 5.4. `reservedParameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#reservedparameters)
+[<InfoBtnBlue/>](/airnode/v0.9/grp-providers/guides/build-an-airnode/api-integration.md#reservedparameters)
 (Required) A list of objects that specify reserved Airnode endpoint parameters
 that do not map to any API operation parameters, but are used for special
 purposes by the Airnode. At a minimum, one object must specify the API response
@@ -475,7 +475,7 @@ override the default value.
 
 ### 5.5. `parameters`
 
-[<InfoBtnBlue/>](/airnode/v0.7/grp-providers/guides/build-an-airnode/api-integration.md#parameters)
+[<InfoBtnBlue/>](/airnode/v0.9/grp-providers/guides/build-an-airnode/api-integration.md#parameters)
 (Required) A list of objects that specify Airnode endpoint parameters that map
 to an particular API operation's parameters. While required, the `parameters`
 array can be empty. Each object has the following elements:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -27,7 +27,6 @@ Operations principally consists of the following components:
   - top-up wallets for those beacons
   - [Airseeker, Airkeeper and Airnode configuration for beacon services.](https://github.com/api3dao/operations/tree/main/data/apis/amberdata/deployments)
 - Metadata around on-chain services including
-  - [policies and read access rights for beacons](https://github.com/api3dao/operations/tree/main/data/policies)
   - [dAPI name to beacon mappings](https://github.com/api3dao/operations/tree/main/data/dapis)
   - [DapiServer contract addresses and ABIs](https://github.com/api3dao/operations/blob/main/data/chains/avalanche.json)
 - Metadata related to the display and user-related representation of beacons and

--- a/docs/qrng/README.md
+++ b/docs/qrng/README.md
@@ -91,7 +91,7 @@ this public utility at the
 
 ## What to expect next?
 
-API3 QRNG is built on [Airnode](/airnode/v0.7/), which means any future
+API3 QRNG is built on [Airnode](/airnode/v0.9/), which means any future
 improvements to Airnode will also be available for API3 QRNG. Most importantly,
 this includes faster, cheaper, and more customizable request fulfillments. In
 addition, integrations to more chains and QRNG providers will be made available

--- a/docs/qrng/guides/qrng-example.md
+++ b/docs/qrng/guides/qrng-example.md
@@ -44,7 +44,7 @@ The QRNG example project
 [sets the sponsor wallet](https://github.com/api3dao/qrng-example/blob/main/deploy/2_setup.js#L11-L28)
 using the requester address. The wallet is then used to pay gas costs when the
 Airnode responds to a request. An alternate method is to use the
-[Admin CLI](/airnode/v0.7/reference/packages/admin-cli.md) as is the case with
+[Admin CLI](/airnode/v0.9/reference/packages/admin-cli.md) as is the case with
 the [Remix Example Project](./remix-example.md).
 
 <airnode-SponsorWalletWarning/>

--- a/docs/qrng/guides/remix-example.md
+++ b/docs/qrng/guides/remix-example.md
@@ -95,7 +95,7 @@ corresponding fields for the function.
 - `_sponsorWallet`: A wallet derived from the requester's contract address, the
   Airnode address, and the Airnode xpub. The wallet is used to pay gas costs to
   acquire a random number. A sponsor wallet must be derived using the command
-  [derive-sponsor-wallet-address](/airnode/v0.7/reference/packages/admin-cli.html#derive-sponsor-wallet-address)
+  [derive-sponsor-wallet-address](/airnode/v0.9/reference/packages/admin-cli.html#derive-sponsor-wallet-address)
   from the Admin CLI. Use the value of the _sponsor wallet address_ that the
   command outputs.
 

--- a/docs/qrng/introduction/how-works.md
+++ b/docs/qrng/introduction/how-works.md
@@ -18,7 +18,7 @@ contract,
 [AirnodeRrpV0](https://github.com/api3dao/airnode/blob/master/packages/airnode-protocol/contracts/rrp/AirnodeRrpV0.sol),
 to acquire a random number.
 
-Upon request, [Airnode](/airnode/v0.7/) calls a designated API operation and
+Upon request, [Airnode](/airnode/v0.9/) calls a designated API operation and
 acquires a random number and then delivers it on-chain, via the `AirnodeRrpV0`
 protocol contract, to a requester.
 
@@ -32,7 +32,7 @@ requester with the random number.
 
 Calling `AirnodeRrpV0` for a random number is the same as any other Airnode
 request. Read more about how a requester
-[accesses an Airnode](/airnode/v0.7/grp-developers/) to acquire data from API
+[accesses an Airnode](/airnode/v0.9/grp-developers/) to acquire data from API
 operations.
 
 ::: tip Gas Costs

--- a/docs/qrng/reference/providers.md
+++ b/docs/qrng/reference/providers.md
@@ -13,7 +13,7 @@ tags:
 <TocHeader />
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
-API3 QRNG is built on [Airnode RRP](/airnode/v0.7/concepts/), and as a result is
+API3 QRNG is built on [Airnode RRP](/airnode/v0.9/concepts/), and as a result is
 provider-agnostic. See below for the providers that are currently available.
 Each provider has an Airnode address with an extended public key (xpub)) and two
 endpoint IDs.


### PR DESCRIPTION
Per slack: policies have been removed from operations (in favour of people using self-serve services). Therefore the policies line can simply be removed.

Other Airnode version corrections in QRNG and OIS