### PR TITLE
Clarify Docker Desktop local provider URL

### DIFF
--- a/docs/airnode/v0.10/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.10/grp-providers/docker/client-image.md
@@ -128,8 +128,8 @@ docker run --detach ^
 
 > If you want to connect Airnode to a blockchain running on localhost, you need
 > to make the blockchain accessible from within the docker itself. If you use
-> docker for linux you can use `--network="host"` parameter. For windows, wsl,
-> mac, and potentially some flavors of Linux like Pop!\_OS, connect to
+> docker for linux you can use `--network="host"` parameter. If you are using
+> Docker Desktop (on any platform), connect to
 > `http://host.docker.internal:8545` instead of `http://127.0.0.1:8545`. See
 > [https://stackoverflow.com/a/24326540](https://stackoverflow.com/a/24326540).
 

--- a/docs/airnode/v0.9/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.9/grp-providers/docker/client-image.md
@@ -128,8 +128,8 @@ docker run --detach ^
 
 > If you want to connect Airnode to a blockchain running on localhost, you need
 > to make the blockchain accessible from within the docker itself. If you use
-> docker for linux you can use `--network="host"` parameter. For windows, wsl,
-> mac, and potentially some flavors of Linux like Pop!\_OS, connect to
+> docker for linux you can use `--network="host"` parameter. If you are using
+> Docker Desktop (on any platform), connect to
 > `http://host.docker.internal:8545` instead of `http://127.0.0.1:8545`. See
 > [https://stackoverflow.com/a/24326540](https://stackoverflow.com/a/24326540).
 


### PR DESCRIPTION
Follow-up to #1120 as we've identified that using Docker Desktop on any platform requires `http://host.docker.internal:8545`.