### PR TITLE
Added small explanation for operation in OIS v1.3

### DIFF
--- a/docs/ois/v1.3/ois.md
+++ b/docs/ois/v1.3/ois.md
@@ -389,8 +389,8 @@ operation.-->
 
 ### 5.2. `operation`
 
-(Optional) An object that refers to an API operation defined in
-`apiSpecifications.paths`, has the following elements:
+(Required if API call won't be skipped) An object that refers to an API
+operation defined in `apiSpecifications.paths`, has the following elements:
 
 - `path`
 - `method`


### PR DESCRIPTION
`operation` is not required if the API call will be skipped. Added an explanation about it.