### PR TITLE
Add --cache property to prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "docs:build": "yarn sync:404; yarn sync:navbar; yarn sync:sidebar; vuepress build docs;",
     "chains:build": "curl https://operations-development.s3.amazonaws.com/latest/chains.json -o ./docs/.vuepress/chains.json",
     "beacons:build": "curl https://operations-development.s3.amazonaws.com/latest/apis.json -o ./docs/.vuepress/beacons.json",
-    "format": "prettier --write \"./**/*.{js,vue,md,json,yaml}\" --loglevel silent",
-    "format:check": "prettier --check \"./**/*.{js,vue,md,json,yaml}\"",
+    "format": "prettier --write --cache \"./**/*.{js,vue,md,json,yaml}\" --loglevel silent",
+    "format:check": "prettier --check --cache \"./**/*.{js,vue,md,json,yaml}\"",
     "prepare": "husky install"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "husky": "^7.0.4",
     "jszip": "^3.7.1",
     "oust": "^1.2.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.8.1",
     "v-click-outside": "^3.1.2",
     "vuepress": "^1.9.7",
     "vuepress-plugin-dehydrate": "^1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6801,10 +6801,10 @@ prettier@^1.18.2:
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+prettier@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
 
 pretty-error@^2.0.2:
   version "2.1.2"


### PR DESCRIPTION
Relates to https://github.com/api3dao/airnode/issues/1595

This greatly reduced the prettier execution time. See the screen shot.

<img width="700" alt="image" src="https://user-images.githubusercontent.com/22679154/207025439-4ae32d43-f2f9-41b2-8369-1e8b4b520471.png">
