### PR TITLE
Replace operations S3 chains source with operations api

### DIFF
--- a/archived/components/beacons/browser2/BeaconList2.vue
+++ b/archived/components/beacons/browser2/BeaconList2.vue
@@ -95,7 +95,7 @@ export default {
           'https://operations-development.s3.amazonaws.com/latest/apis.json'
         );
         const responseChains = await axios.get(
-          'https://operations-development.s3.amazonaws.com/latest/chains.json '
+          'https://db-api-prod.api3.org/api/docs-chains-reference'
         );
         const providers = response.data;
         const chains = responseChains.data;

--- a/docs/.vuepress/components/dapis/browsers/DapiList.vue
+++ b/docs/.vuepress/components/dapis/browsers/DapiList.vue
@@ -97,7 +97,7 @@ export default {
   methods: {
     async init() {
       const responseChains = await axios.get(
-        'https://operations-development.s3.amazonaws.com/latest/chains.json '
+        'https://db-api-prod.api3.org/api/docs-chains-reference'
       );
       this.chains = responseChains.data;
       this.chains = this.sortChainsByName(this.chains);

--- a/docs/.vuepress/components/dapis/chains/ChainsList.vue
+++ b/docs/.vuepress/components/dapis/chains/ChainsList.vue
@@ -46,7 +46,7 @@ export default {
     async loadChainsFromRepo() {
       try {
         const response = await axios.get(
-          'https://operations-development.s3.amazonaws.com/latest/chains.json '
+          'https://db-api-prod.api3.org/api/docs-chains-reference'
         );
         this.chains = this.sortByName(response.data);
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sync:sidebar": "cp docs/.vuepress/components/Sidebar.vue node_modules/@vuepress/theme-default/components/Sidebar.vue",
     "docs:dev": "yarn sync:404; yarn sync:navbar; yarn sync:sidebar; vuepress dev docs",
     "docs:build": "yarn sync:404; yarn sync:navbar; yarn sync:sidebar; vuepress build docs;",
-    "chains:build": "curl https://operations-development.s3.amazonaws.com/latest/chains.json -o ./docs/.vuepress/chains.json",
+    "chains:build": "curl https://db-api-prod.api3.org/api/docs-chains-reference -o ./docs/.vuepress/chains.json",
     "beacons:build": "curl https://operations-development.s3.amazonaws.com/latest/apis.json -o ./docs/.vuepress/beacons.json",
     "format": "prettier --write --cache \"./**/*.{js,vue,md,json,yaml}\" --loglevel silent",
     "format:check": "prettier --check --cache \"./**/*.{js,vue,md,json,yaml}\"",


### PR DESCRIPTION
@wkande This will replace the old (operations) source for chains with the new operations API endpoint. 

There are a lot more chains here and some of them don't have all of the deployment data so perhaps we should wait on merging this until everything is filled (or alternatively filter them out for now). I'll get back on this point.

Closes #1166