### PR TITLE
Remove --detach from airnode-client commands

### DIFF
--- a/docs/airnode/v0.10/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.10/grp-providers/docker/client-image.md
@@ -86,15 +86,14 @@ container. The below commands are run from the depicted directory.
 
 ### Running Airnode
 
-It is recommended to run the Airnode in a detached mode using the `--detach`
-parameter, but you may run the it without it as well.
+Use the following command to run Airnode:
 
 :::: tabs
 
 ::: tab Linux/Mac/WSL2
 
 ```sh
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.10.0
@@ -105,7 +104,7 @@ docker run --detach \
 ::: tab Windows PowerShell
 
 ```powershell
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.10.0
@@ -116,7 +115,7 @@ docker run --detach \
 ::: tab Windows
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume %cd%:/app/config ^
   --name airnode ^
   api3/airnode-client:0.10.0
@@ -135,15 +134,9 @@ docker run --detach ^
 
 ### Checking Airnode logs
 
-If you run the Airnode in a detached mode, you need to use the `logs` command to
-access the logs. You can also use `--follow` parameter to stream the Airnode log
-output.
-
-```bash
-docker logs airnode
-```
-
-or
+Logs will be output to the console after running the above command. If you
+decide to run Airnode in detached mode with `--detach`, you need to use the
+`logs` command, optionally with `--follow`, to access the logs.
 
 ```bash
 docker logs --follow airnode

--- a/docs/airnode/v0.10/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.10/grp-providers/tutorial/quick-deploy-container/README.md
@@ -117,7 +117,7 @@ of `api3/airnode-client` matches the `nodeVersion` in the config.json file.
 ::: tab Mac/WSL2/PowerShell
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --publish 3000:3000 \
@@ -131,7 +131,7 @@ docker run --detach \
 For Windows CMD:
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume "%cd%:/app/config" ^
   --name quick-deploy-container-airnode ^
   --publish 3000:3000 ^
@@ -143,7 +143,7 @@ docker run --detach ^
 ::: tab Linux
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --network host \

--- a/docs/airnode/v0.11/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.11/grp-providers/docker/client-image.md
@@ -86,15 +86,14 @@ container. The below commands are run from the depicted directory.
 
 ### Running Airnode
 
-It is recommended to run the Airnode in a detached mode using the `--detach`
-parameter, but you may run the it without it as well.
+Use the following command to run Airnode:
 
 :::: tabs
 
 ::: tab Linux/Mac/WSL2
 
 ```sh
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.11.0
@@ -105,7 +104,7 @@ docker run --detach \
 ::: tab Windows PowerShell
 
 ```powershell
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.11.0
@@ -116,7 +115,7 @@ docker run --detach \
 ::: tab Windows
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume %cd%:/app/config ^
   --name airnode ^
   api3/airnode-client:0.11.0
@@ -135,15 +134,9 @@ docker run --detach ^
 
 ### Checking Airnode logs
 
-If you run the Airnode in a detached mode, you need to use the `logs` command to
-access the logs. You can also use `--follow` parameter to stream the Airnode log
-output.
-
-```bash
-docker logs airnode
-```
-
-or
+Logs will be output to the console after running the above command. If you
+decide to run Airnode in detached mode with `--detach`, you need to use the
+`logs` command, optionally with `--follow`, to access the logs.
 
 ```bash
 docker logs --follow airnode

--- a/docs/airnode/v0.11/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.11/grp-providers/tutorial/quick-deploy-container/README.md
@@ -117,7 +117,7 @@ of `api3/airnode-client` matches the `nodeVersion` in the config.json file.
 ::: tab Mac/WSL2/PowerShell
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --publish 3000:3000 \
@@ -131,7 +131,7 @@ docker run --detach \
 For Windows CMD:
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume "%cd%:/app/config" ^
   --name quick-deploy-container-airnode ^
   --publish 3000:3000 ^
@@ -143,7 +143,7 @@ docker run --detach ^
 ::: tab Linux
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --network host \

--- a/docs/airnode/v0.9/grp-providers/docker/client-image.md
+++ b/docs/airnode/v0.9/grp-providers/docker/client-image.md
@@ -86,15 +86,14 @@ container. The below commands are run from the depicted directory.
 
 ### Running Airnode
 
-It is recommended to run the Airnode in a detached mode using the `--detach`
-parameter, but you may run the it without it as well.
+Use the following command to run Airnode:
 
 :::: tabs
 
 ::: tab Linux/Mac/WSL2
 
 ```sh
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.9.2
@@ -105,7 +104,7 @@ docker run --detach \
 ::: tab Windows PowerShell
 
 ```powershell
-docker run --detach \
+docker run \
   --volume $(pwd):/app/config \
   --name airnode \
   api3/airnode-client:0.9.2
@@ -116,7 +115,7 @@ docker run --detach \
 ::: tab Windows
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume %cd%:/app/config ^
   --name airnode ^
   api3/airnode-client:0.9.2
@@ -135,15 +134,9 @@ docker run --detach ^
 
 ### Checking Airnode logs
 
-If you run the Airnode in a detached mode, you need to use the `logs` command to
-access the logs. You can also use `--follow` parameter to stream the Airnode log
-output.
-
-```bash
-docker logs airnode
-```
-
-or
+Logs will be output to the console after running the above command. If you
+decide to run Airnode in detached mode with `--detach`, you need to use the
+`logs` command, optionally with `--follow`, to access the logs.
 
 ```bash
 docker logs --follow airnode

--- a/docs/airnode/v0.9/grp-providers/tutorial/quick-deploy-container/README.md
+++ b/docs/airnode/v0.9/grp-providers/tutorial/quick-deploy-container/README.md
@@ -120,7 +120,7 @@ of `api3/airnode-client` matches the `nodeVersion` in the config.json file.
 ::: tab Mac/WSL2/PowerShell
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --publish 3000:3000 \
@@ -134,7 +134,7 @@ docker run --detach \
 For Windows CMD:
 
 ```batch
-docker run --detach ^
+docker run ^
   --volume "%cd%:/app/config" ^
   --name quick-deploy-container-airnode ^
   --publish 3000:3000 ^
@@ -146,7 +146,7 @@ docker run --detach ^
 ::: tab Linux
 
 ```sh
-docker run --detach \
+docker run \
   --volume "$(pwd):/app/config" \
   --name quick-deploy-container-airnode \
   --network host \


### PR DESCRIPTION
Closes #1213. The `docker run` arguments `-it` aren't needed in this case and arent' used in `airnode-examples`:

https://github.com/api3dao/airnode/blob/08a2985a4cde546283956457c9a87f1237d7e380/packages/airnode-examples/src/scripts/run-airnode-locally.ts#L25-L39