### PR TITLE
Update DAO Tracker URLs

### DIFF
--- a/docs/dao-members/dashboard/dao-tracker.md
+++ b/docs/dao-members/dashboard/dao-tracker.md
@@ -12,11 +12,11 @@ tags:
 
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
-The [DAO Tracker](https://enormous.cloud/dao/api3/tracker/) is a
-community-developed tool that provides additional insight into the DAO beyond
-what is offered by the intentionally minimalist DAO Dashboard. Its
-[open source codebase](https://github.com/EnormousCloud/api3-dao-tracker) was
-developed by GitHub user [EnormousCloud](https://github.com/EnormousCloud).
+The [DAO Tracker](https://tracker.api3.org/) is a community-developed tool that
+provides additional insight into the DAO beyond what is offered by the
+intentionally minimalist DAO Dashboard. Its
+[open source codebase](https://github.com/api3dao/api3-tracker) was developed by
+GitHub user [EnormousCloud](https://github.com/EnormousCloud).
 
 The DAO Tracker features the following pages and content:
 

--- a/docs/dao-members/dashboard/proposals.md
+++ b/docs/dao-members/dashboard/proposals.md
@@ -22,7 +22,7 @@ This required percentage, as well as other DAO parameters, can be adjusted by
 the DAO as described in
 [Dashboard Attributes](../contract-architecture/dashboard-attributes.md). To
 view the percentage of staked tokens in the pool for an address, visit the
-[DAO Tracker wallets page](https://enormous.cloud/dao/api3/tracker/wallets).
+[DAO Tracker wallets page](https://tracker.api3.org/wallets).
 
 You can vote on all proposals regardless of the percentage of staked tokens in
 the pool you own. See [How to Vote](voting.md) for instructions. Alternatively,


### PR DESCRIPTION
This PR updates DAO Tracker URLs to the `api3.org` domain.