### PR TITLE
Hide older version banner

### DIFF
--- a/docs/.vuepress/components/VersionWarning.vue
+++ b/docs/.vuepress/components/VersionWarning.vue
@@ -4,10 +4,15 @@ Each page in a doc set adds this component under its title and before
 the TOC if used.
 
 WARNING: Do not place HTML comment lines inside paragraph elements.
+
+April 2023, this banner is no longer needed. The v-if="1===2" was added
+to hide it. All versions are legacy in api3-docs after vitepress-docs was
+activated.
 -->
 
 <template>
-  <div v-if="show" class="custom-block danger">
+  <div v-if="1 === 2" class="custom-block danger">
+    <!--div v-if="show" class="custom-block danger"-->
     <p class="custom-block-title">Newer Version Available</p>
     <p>
       You are viewing an older version of the {{ docSet }} documentation set.

--- a/docs/.vuepress/public/CNAME
+++ b/docs/.vuepress/public/CNAME
@@ -1,1 +1,1 @@
-docs.api3.org
+old-docs.api3.org

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ navbar: false
           "
         >
           <span style="opacity: 1.5;"
-            >Newer release of the API3 Technical documentation available.
+            >A newer release of the API3 Technical documentation is available.
             <br/><br/>https://docs.api3.org.</span
           >
         </div>

--- a/libs/Page.vue
+++ b/libs/Page.vue
@@ -16,19 +16,20 @@
             background-color: green;
             color: white;
             text-align: center;
-            margin-bottom: 20px;
+
             border-radius: 0.3em;
           "
         >
           <span style="opacity: 1.5"
-            >Newer release of the API3 Technical documentation available.</span
+            >A newer release of the API3 Technical documentation is
+            available.</span
           >
         </div>
       </a>
     </div>
 
-    <!-- wkande 04/2023 Added style="margin-top: 20px" to the following Content element -->
-    <Content class="theme-default-content" style="margin-top: 20px" />
+    <!-- wkande 04/2023 Added style="margin-top: 40px" to the following Content element -->
+    <Content class="theme-default-content" style="margin-top: 40px" />
     <PageEdit />
 
     <PageNav v-bind="{ sidebarItems }" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api3-docs",
-  "version": "0.11.0",
+  "version": "0.10.0",
   "description": "API3 Developer Documentation.",
   "main": "index.js",
   "repository": "https://github.com/api3dao/api3-docs",


### PR DESCRIPTION
Also changed the `CNAME` file in /public. It was still pointing to `doc.api3.org` rather than `old-docs.api3.org`.