### PR TITLE
fix: remove use of references.json chainNames field

### DIFF
--- a/.github/workflows/firebase-deployment.yml
+++ b/.github/workflows/firebase-deployment.yml
@@ -30,6 +30,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SA_API3_DOCS }}'
           expires: 7d
           channelId: ${{ steps.get_branch.outputs.branch_name }}
+          firebaseToolsVersion: '11.30.0'
         id: firebase_deploy
 
       - uses: actions/github-script@v6

--- a/docs/.vuepress/components/airnode/ContractAddresses.vue
+++ b/docs/.vuepress/components/airnode/ContractAddresses.vue
@@ -85,20 +85,9 @@ export default {
         let notImportantArr = [];
 
         for (const key in response.data[this.contractName]) {
-          // Here the network is not in chainsRef list
-          // Is it a testnet or mainnet, tell by its repo name
+          // Skip if the network is not in chainsRef list
           if (!chainsRef[key]) {
-            let network = 'mainnet';
-            if (response.data.chainNames[key].indexOf('testnet') > -1) {
-              network = 'testnet';
-            }
-            importantArr.push({
-              address: response.data[this.contractName][key],
-              chainId: parseInt(key),
-              fullname: response.data.chainNames[key],
-              type: network,
-            });
-            // Here the chain is in the chainsRef list
+            continue;
           } else if (chainsRef[key].type === this.type) {
             if (important.includes(parseInt(key))) {
               importantArr.push({

--- a/docs/dapis/reference/chains.md
+++ b/docs/dapis/reference/chains.md
@@ -7,9 +7,6 @@ folder: Reference
 
 # {{$frontmatter.title}}
 
-dAPIs can be read on the following chains using the
-[DapiServer](../#dapiserver-sol) contract addresses listed below. Use the
-[API3 Market](https://market.api3.org/) website to find the desired dAPI names
-and the networks they are available on.
-
-<dapis-chains-ChainsList/>
+Please refer to the new API3 documentation's
+[dAPIs Reference](https://docs.api3.org/reference/dapis/chains/) for the latest
+technical details on accessing dAPIs.

--- a/docs/dapis/reference/chains.md
+++ b/docs/dapis/reference/chains.md
@@ -7,6 +7,6 @@ folder: Reference
 
 # {{$frontmatter.title}}
 
-Please refer to the new API3 documentation's
-[dAPIs Reference](https://docs.api3.org/reference/dapis/chains/) for the latest
-technical details on accessing dAPIs.
+Please refer to the new API3 documentation for the latest
+[Chains and Contracts](https://docs.api3.org/reference/dapis/chains/) page.
+There you will also find the current technical information on accessing dAPIs.


### PR DESCRIPTION
Closes #1242. Since these old docs are deprecated, I've opted for skipping the display of chains that aren't present in [chains.json](https://github.com/api3dao/api3-docs/blob/main/docs/.vuepress/chains.json) rather than invest in upgrading these docs to use @api3/chains. 